### PR TITLE
Redesign career page with professional styling

### DIFF
--- a/app/(app)/(tabs)/karriere/[karriereId].tsx
+++ b/app/(app)/(tabs)/karriere/[karriereId].tsx
@@ -1,19 +1,101 @@
 import { JOBTYPES } from "@/components/karriere/jobpostcard";
 import { Text } from "@/components/ui/text";
-import { Card } from "@/components/ui/card";
 import { useQuery } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams } from "expo-router";
-import { Image, ScrollView, View } from "react-native";
+import { Image, Pressable, ScrollView, View } from "react-native";
 import * as WebBrowser from 'expo-web-browser';
-import { Button } from "@/components/ui/button";
 import MarkdownView from "@/components/ui/MarkdownView";
 import PageWrapper from "@/components/ui/pagewrapper";
 import { BASE_URL } from "@/actions/constant";
 import useRefresh from "@/lib/useRefresh";
+import { useColorScheme } from "@/lib/useColorScheme";
+import {
+    Building2,
+    CalendarClock,
+    GraduationCap,
+    BriefcaseBusiness,
+    MapPin,
+    Mail,
+    ExternalLink,
+} from "lucide-react-native";
+import { SectionHeader } from "@/components/ui/section-header";
+
+function DetailRow({
+    icon,
+    label,
+    value,
+    isLast = false,
+}: {
+    icon: React.ReactNode;
+    label: string;
+    value: string;
+    isLast?: boolean;
+}) {
+    return (
+        <>
+            <View className="flex-row items-center px-4 py-3.5">
+                {icon}
+                <View className="ml-3 flex-1">
+                    <Text className="text-xs text-muted-foreground mb-0.5" style={{ fontFamily: "Inter" }}>
+                        {label}
+                    </Text>
+                    <Text className="text-base text-foreground" numberOfLines={1}>
+                        {value}
+                    </Text>
+                </View>
+            </View>
+            {!isLast && <View className="h-px bg-border dark:bg-muted ml-12" />}
+        </>
+    );
+}
+
+function DetailSkeleton() {
+    return (
+        <PageWrapper className="flex-1 bg-background">
+            <ScrollView showsVerticalScrollIndicator={false}>
+                {/* Image skeleton */}
+                <View className="w-full aspect-[16/9] bg-muted dark:bg-secondary/40 animate-pulse" />
+
+                <View className="px-6 pt-5">
+                    {/* Title skeleton */}
+                    <View className="h-7 w-3/4 bg-muted dark:bg-secondary/40 rounded-md animate-pulse mb-2" />
+                    <View className="h-4 w-1/3 bg-muted dark:bg-secondary/40 rounded-md animate-pulse mb-6" />
+
+                    {/* Details skeleton */}
+                    <View className="bg-gray-100 dark:bg-secondary/30 rounded-2xl overflow-hidden mb-6">
+                        {[1, 2, 3, 4].map((i) => (
+                            <View key={i}>
+                                <View className="flex-row items-center px-4 py-3.5">
+                                    <View className="w-[18px] h-[18px] bg-muted dark:bg-secondary/50 rounded animate-pulse" />
+                                    <View className="ml-3">
+                                        <View className="h-3 w-16 bg-muted dark:bg-secondary/50 rounded animate-pulse mb-1.5" />
+                                        <View className="h-4 w-32 bg-muted dark:bg-secondary/50 rounded animate-pulse" />
+                                    </View>
+                                </View>
+                                {i < 4 && <View className="h-px bg-border dark:bg-muted ml-12" />}
+                            </View>
+                        ))}
+                    </View>
+
+                    {/* Button skeleton */}
+                    <View className="h-14 bg-muted dark:bg-secondary/40 rounded-2xl animate-pulse mb-6" />
+
+                    {/* Content skeleton */}
+                    <View className="gap-2">
+                        <View className="h-4 w-full bg-muted dark:bg-secondary/40 rounded animate-pulse" />
+                        <View className="h-4 w-5/6 bg-muted dark:bg-secondary/40 rounded animate-pulse" />
+                        <View className="h-4 w-4/6 bg-muted dark:bg-secondary/40 rounded animate-pulse" />
+                    </View>
+                </View>
+            </ScrollView>
+        </PageWrapper>
+    );
+}
 
 export default function Karriereside() {
     const params = useLocalSearchParams();
     const id = params.karriereId;
+    const { isDarkColorScheme } = useColorScheme();
 
     const jobpost = useQuery({
         queryKey: ["jobpost", id],
@@ -23,66 +105,127 @@ export default function Karriereside() {
     });
 
     const refreshControl = useRefresh(["jobpost", id as string]);
+    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
 
     if (jobpost.isPending) return (
-        <View>
+        <>
             <Stack.Screen options={{ title: "" }} />
-            <Text>Loading...</Text>
-        </View>
-    )
-    if (jobpost.isError) return <Text>Error: {jobpost.error.message}</Text>
+            <DetailSkeleton />
+        </>
+    );
+
+    if (jobpost.isError) return (
+        <PageWrapper className="flex-1 bg-background">
+            <Stack.Screen options={{ title: "" }} />
+            <View className="flex-1 items-center justify-center px-6">
+                <Text className="text-base text-destructive">{jobpost.error.message}</Text>
+            </View>
+        </PageWrapper>
+    );
 
     const handleApply = async () => {
         await WebBrowser.openBrowserAsync(jobpost.data.link);
     }
 
+    const formattedDeadline = new Date(jobpost.data.deadline).toLocaleDateString("no-NO", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    });
+
     return (
         <>
             <Stack.Screen options={{ title: jobpost.data.company }} />
-            <PageWrapper>
-                <ScrollView refreshControl={refreshControl}>
-                    <View>
-                        <Image className="w-full h-48" resizeMode="cover" source={{ uri: jobpost.data.image }} />
-                    </View>
-                    <View className="flex flex-col text-3xl px-2 py-5">
-                        <Text className="text-4xl font-semibold pl-2">{jobpost.data.title}</Text>
-                        <Card className="mx-auto w-[100%] border-2 border-gray-200 dark:border-gray-900 bg-card rounded-lg mt-5 px-3 py-2">
-                            <Text className="text-2xl mb-4 font-bold">Detaljer</Text>
-                            <View className="flex flex-row justify-start items-start">
-                                <View className="ml-2 mr-10">
-                                    <Text className="text-md text-muted-foreground mb-2">Bedrift:</Text>
-                                    <Text className="text-md text-muted-foreground mb-2">Søknadsfrist</Text>
-                                    <Text className="text-md text-muted-foreground mb-2">Årstrinn:</Text>
-                                    <Text className="text-md text-muted-foreground mb-2">Stillingstype:</Text>
-                                    <Text className="text-md text-muted-foreground mb-2">Sted:</Text>
-                                    <Text className="text-md text-muted-foreground mb-2">Kontakt:</Text>
-                                </View>
-                                <View>
-                                    <Text className="text-md mb-2">{jobpost.data.company}</Text>
-                                    <Text className="text-md mb-2">{jobpost.data.company}</Text>
-                                    <Text className="text-md mb-2">{new Date(jobpost.data.deadline).toLocaleDateString("no-NO", {
-                                        year: "numeric",
-                                        month: "long",
-                                        day: "numeric",
-                                    })}</Text>
-                                    <Text className="text-md mb-2">{jobpost.data.class_start}. - {jobpost.data.class_end}.</Text>
-                                    <Text className="text-md mb-2">{JOBTYPES[jobpost.data.job_type as keyof typeof JOBTYPES]}</Text>
-                                    <Text className="text-md mb-2">{jobpost.data.location}</Text>
-                                    {jobpost.data.email &&
-                                        <Text className="text-md mb-2">{jobpost.data.email}</Text>
-                                    }
-                                </View>
+            <PageWrapper className="flex-1 bg-background">
+                <ScrollView
+                    refreshControl={refreshControl}
+                    showsVerticalScrollIndicator={false}
+                    contentContainerStyle={{ paddingBottom: 40 }}
+                >
+                    {/* Hero image */}
+                    {jobpost.data.image && (
+                        <View className="w-full aspect-[16/9] overflow-hidden">
+                            <Image
+                                className="w-full h-full"
+                                resizeMode="cover"
+                                source={{ uri: jobpost.data.image }}
+                            />
+                        </View>
+                    )}
 
-                            </View>
-                        </Card>
-                        {jobpost.data.link &&
-                            <Button onPress={handleApply} className="w-full mt-5 mb-6" size="lg" variant="default">
-                                <Text className="font-medium">
-                                    Søk nå!
+                    <View className="px-6">
+                        {/* Title section */}
+                        <View className="pt-5 pb-1 mb-4">
+                            <Text className="text-2xl font-bold text-foreground mb-1">
+                                {jobpost.data.title}
+                            </Text>
+                            <Text className="text-base text-muted-foreground">
+                                {jobpost.data.company}
+                            </Text>
+                        </View>
+
+                        {/* Details card — profile page style */}
+                        <View className="bg-gray-100 dark:bg-secondary/30 rounded-2xl overflow-hidden mb-6">
+                            <DetailRow
+                                icon={<Building2 size={18} color={mutedColor} />}
+                                label="Bedrift"
+                                value={jobpost.data.company}
+                            />
+                            <DetailRow
+                                icon={<CalendarClock size={18} color={mutedColor} />}
+                                label="Søknadsfrist"
+                                value={formattedDeadline}
+                            />
+                            {jobpost.data.class_start && jobpost.data.class_end && (
+                                <DetailRow
+                                    icon={<GraduationCap size={18} color={mutedColor} />}
+                                    label="Årstrinn"
+                                    value={`${jobpost.data.class_start}. - ${jobpost.data.class_end}. trinn`}
+                                />
+                            )}
+                            <DetailRow
+                                icon={<BriefcaseBusiness size={18} color={mutedColor} />}
+                                label="Stillingstype"
+                                value={JOBTYPES[jobpost.data.job_type as keyof typeof JOBTYPES]}
+                            />
+                            <DetailRow
+                                icon={<MapPin size={18} color={mutedColor} />}
+                                label="Sted"
+                                value={jobpost.data.location}
+                            />
+                            {jobpost.data.email && (
+                                <DetailRow
+                                    icon={<Mail size={18} color={mutedColor} />}
+                                    label="Kontakt"
+                                    value={jobpost.data.email}
+                                    isLast
+                                />
+                            )}
+                        </View>
+
+                        {/* Apply button — login page style */}
+                        {jobpost.data.link && (
+                            <Pressable
+                                onPress={handleApply}
+                                className="h-14 rounded-2xl bg-primary dark:bg-[#1C5ECA] flex-row items-center justify-center mb-8 active:opacity-80"
+                            >
+                                <Text
+                                    className="text-white text-base font-semibold mr-2"
+                                    style={{ fontFamily: "Inter" }}
+                                >
+                                    Søk nå
                                 </Text>
-                            </Button>
-                        }
-                        <MarkdownView content={jobpost.data.body} />
+                                <ExternalLink size={16} color="white" />
+                            </Pressable>
+                        )}
+
+                        {/* Description */}
+                        {jobpost.data.body && (
+                            <View className="mb-4">
+                                <SectionHeader title="Om stillingen" className="mb-4" />
+                                <MarkdownView content={jobpost.data.body} />
+                            </View>
+                        )}
                     </View>
                 </ScrollView>
             </PageWrapper>

--- a/app/(app)/(tabs)/karriere/_layout.tsx
+++ b/app/(app)/(tabs)/karriere/_layout.tsx
@@ -6,21 +6,24 @@ export default function KarriereLayout() {
     const router = useRouter();
 
     return (
-        <Stack>
+        <Stack
+            screenOptions={{
+                headerBackTitle: "Tilbake",
+            }}
+        >
             <Stack.Screen
                 name="index"
                 options={{
                     headerShown: true,
                     title: "Jobbannonser",
+                    headerBackTitle: "Tilbake",
                     headerTitleAlign: "center",
                     headerRight: () => (
                         <TouchableWithoutFeedback onPressIn={() => router.push("/profil")}>
-                            <View>
-                                <Icon icon="UserRound" className="self-center stroke-2 dark:text-white" />
+                            <View className="w-10 h-10 items-center justify-center">
+                                <Icon icon="UserRound" className="stroke-2 dark:text-white" />
                             </View>
                         </TouchableWithoutFeedback>
-
-
                     ),
                 }}
             />

--- a/app/(app)/(tabs)/karriere/index.tsx
+++ b/app/(app)/(tabs)/karriere/index.tsx
@@ -2,12 +2,16 @@ import { BASE_URL } from "@/actions/constant";
 import JobPostCard, { JobPostCardSkeleton } from "@/components/karriere/jobpostcard";
 import PageWrapper from "@/components/ui/pagewrapper";
 import { Text } from "@/components/ui/text";
+import { SectionHeader } from "@/components/ui/section-header";
 import useRefresh from "@/lib/useRefresh";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "expo-router";
 import { ScrollView, View } from "react-native";
+import { BriefcaseBusiness } from "lucide-react-native";
+import { useColorScheme } from "@/lib/useColorScheme";
 
 export default function Karriere() {
+    const { isDarkColorScheme } = useColorScheme();
 
     const jobposts = useQuery({
         queryKey: ["jobposts"],
@@ -18,32 +22,73 @@ export default function Karriere() {
 
     const refreshControl = useRefresh("jobposts");
 
-    if (jobposts.isError) return <Text>Error: {jobposts.error.message}</Text>
+    if (jobposts.isError) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="flex-1 items-center justify-center px-6">
+                    <Text className="text-base text-destructive">{jobposts.error.message}</Text>
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    const resultCount = jobposts.data?.results?.length ?? 0;
 
     return (
-        <PageWrapper className="w-full h-fit mt-2">
-            <ScrollView refreshControl={refreshControl}>
-                <View className="flex flex-col justify-center gap-4 pb-20 px-2">
-                    {
-                        jobposts.data?.results.map((jobpost: any) => (
-                            <Link href={`/(tabs)/karriere/${jobpost.id}`} key={jobpost.id}>
-                                <JobPostCard
-                                    title={jobpost.title}
-                                    jobType={jobpost.job_type}
-                                    deadline={jobpost.deadline}
-                                    location={jobpost.location}
-                                    image={jobpost.image}
-                                />
-                            </Link>
-                        ))
-                    }
-                    {jobposts.isPending &&
+        <PageWrapper className="flex-1 bg-background">
+            <ScrollView
+                refreshControl={refreshControl}
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingBottom: 40 }}
+            >
+                {/* Header section */}
+                {!jobposts.isPending && (
+                    <View className="px-4 pt-4">
+                        <SectionHeader
+                            title={`${resultCount} ${resultCount === 1 ? 'stilling' : 'stillinger'} tilgjengelig`}
+                        />
+                    </View>
+                )}
+
+                {/* Job post list */}
+                <View>
+                    {jobposts.data?.results.map((jobpost: any) => (
+                        <Link href={`/(tabs)/karriere/${jobpost.id}`} key={jobpost.id}>
+                            <JobPostCard
+                                title={jobpost.title}
+                                jobType={jobpost.job_type}
+                                deadline={jobpost.deadline}
+                                location={jobpost.location}
+                                image={jobpost.image}
+                                company={jobpost.company}
+                            />
+                        </Link>
+                    ))}
+                    {jobposts.isPending && (
                         <>
                             <JobPostCardSkeleton />
                             <JobPostCardSkeleton />
                             <JobPostCardSkeleton />
                         </>
-                    }
+                    )}
+
+                    {/* Empty state */}
+                    {!jobposts.isPending && resultCount === 0 && (
+                        <View className="py-16 items-center">
+                            <View className="w-16 h-16 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-4">
+                                <BriefcaseBusiness
+                                    size={28}
+                                    color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'}
+                                />
+                            </View>
+                            <Text className="text-lg font-semibold text-foreground mb-1">
+                                Ingen stillinger
+                            </Text>
+                            <Text className="text-sm text-muted-foreground text-center px-8">
+                                Det er ingen jobbannonser tilgjengelig akkurat nå. Sjekk igjen senere!
+                            </Text>
+                        </View>
+                    )}
                 </View>
             </ScrollView>
         </PageWrapper>

--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -4,7 +4,7 @@ import { ThemeToggle } from '@/components/themeToggle';
 export default function AppLayout() {
     return (
         <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="(tabs)" options={{ headerShown: false, headerBackTitle: "Tilbake" }} />
             <Stack.Screen
                 name="profil"
                 options={{

--- a/app/(app)/profil/_layout.tsx
+++ b/app/(app)/profil/_layout.tsx
@@ -3,7 +3,7 @@ import { Stack } from "expo-router";
 export default function profilLayout() {
 
     return (
-        <Stack>
+        <Stack screenOptions={{ headerBackTitle: "" }}>
             <Stack.Screen
                 name="index"
                 options={{

--- a/app/(app)/profil/index.tsx
+++ b/app/(app)/profil/index.tsx
@@ -23,6 +23,7 @@ import EventCard, {
 import useRefresh from "@/lib/useRefresh";
 import { Mail, GraduationCap, LogOut, TriangleAlert } from "lucide-react-native";
 import { useColorScheme } from "@/lib/useColorScheme";
+import { SectionHeader } from "@/components/ui/section-header";
 
 export default function Profil() {
     const { setAuthState } = useAuth();
@@ -145,9 +146,7 @@ export default function Profil() {
 
                 {/* Events */}
                 <View className="px-6 mb-6">
-                    <Text className="text-lg font-semibold text-foreground mb-3">
-                        Påmeldte arrangementer
-                    </Text>
+                    <SectionHeader title="Påmeldte arrangementer" />
                     <DisplayUserEvents userEvents={userEvents} router={router} />
                 </View>
 

--- a/components/karriere/jobpostcard.tsx
+++ b/components/karriere/jobpostcard.tsx
@@ -1,8 +1,8 @@
 import { Image, View } from "react-native";
 import { Text } from "../ui/text";
-import Icon from "@/lib/icons/Icon";
-import timeformat from "@/lib/timeformat";
+import { BriefcaseBusiness, MapPin, Building2 } from "lucide-react-native";
 import ImageMissing from '../ui/imageMissing';
+import { useColorScheme } from "@/lib/useColorScheme";
 
 export interface JobPostProps {
     title: string;
@@ -10,6 +10,7 @@ export interface JobPostProps {
     deadline: string;
     jobType: keyof typeof JOBTYPES;
     image: string | null;
+    company: string;
 }
 
 export const JOBTYPES = {
@@ -19,42 +20,94 @@ export const JOBTYPES = {
     OTHER: "Annet"
 }
 
-export default function JobPostCard(props: JobPostProps) {
+function DeadlineBadge({ deadline }: { deadline: string }) {
+    const date = new Date(deadline);
+    const now = new Date();
+    const daysLeft = Math.ceil((date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+    const isUrgent = daysLeft <= 7 && daysLeft >= 0;
+    const isPast = daysLeft < 0;
+
+    const formatted = date.toLocaleDateString('no-NO', {
+        day: 'numeric',
+        month: 'short',
+    });
+
     return (
-        <View className="w-full h-fit border-2 border-gray-200 dark:border-gray-900 rounded-lg bg-card">
-            <View className="relative">
-                <View className="absolute left-0.5 top-0.5 bg-gray-900 px-3 py-1 rounded-lg z-50">
-                    <Text className="text-center text-sm text-white">
-                        {new Date(props.deadline).toLocaleDateString('no-NO', { day: 'numeric', month: 'short' })} {new Date(props.deadline).getFullYear()}
-                    </Text>
-                </View>
-                <View className="w-full aspect-[16/7] overflow-hidden rounded-t-lg">
-                    {props.image ? (
-                        <Image
-                            source={{ uri: props.image }}
-                            className="w-full h-full m-0 p-0"
-                            resizeMode="cover"
-                        />
-                    ) : (
-                        <ImageMissing />
-                    )}
-                </View>
+        <View className={`px-3 py-1 rounded-full ${
+            isPast
+                ? 'bg-destructive/15 dark:bg-destructive/25'
+                : isUrgent
+                    ? 'bg-orange-100 dark:bg-orange-500/20'
+                    : 'bg-primary/10 dark:bg-primary/20'
+        }`}>
+            <Text className={`text-xs font-semibold ${
+                isPast
+                    ? 'text-destructive'
+                    : isUrgent
+                        ? 'text-orange-600 dark:text-orange-400'
+                        : 'text-primary dark:text-accent'
+            }`} style={{ fontFamily: "Inter" }}>
+                {isPast ? 'Utløpt' : `Frist ${formatted}`}
+            </Text>
+        </View>
+    );
+}
+
+export default function JobPostCard(props: JobPostProps) {
+    const { isDarkColorScheme } = useColorScheme();
+    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+
+    return (
+        <View className="pb-7">
+            {/* Full-width image */}
+            <View className="w-full aspect-[2/1] overflow-hidden">
+                {props.image ? (
+                    <Image
+                        source={{ uri: props.image }}
+                        className="w-full h-full"
+                        resizeMode="cover"
+                    />
+                ) : (
+                    <ImageMissing />
+                )}
             </View>
 
-            <View className="flex flex-col gap-3 px-2 pb-3">
-                <Text className="text-2xl mt-2 mb-2 font-semibold">{props.title}</Text>
-                <View className="flex flex-row gap-2 ml-2 items-center">
-                    <Icon icon="BriefcaseBusiness" className="w-6 h-6 self-center stroke-1 dark:text-white" />
-                    <Text className="">{JOBTYPES[props.jobType]}</Text>
+            {/* Content */}
+            <View className="px-4 pt-3.5">
+                {/* Header row: company + deadline */}
+                <View className="flex-row items-center justify-between mb-2">
+                    <View className="flex-row items-center flex-1 mr-3">
+                        <Building2 size={14} color={mutedColor} />
+                        <Text className="text-sm text-muted-foreground ml-1.5 font-medium" numberOfLines={1}>
+                            {props.company}
+                        </Text>
+                    </View>
+                    <DeadlineBadge deadline={props.deadline} />
                 </View>
-                <View className="flex flex-row gap-2 ml-2 items-center">
-                    <Icon icon="MapPin" className="w-6 h-6 self-center stroke-1 dark:text-white" />
-                    <Text className="">{props.location}</Text>
+
+                {/* Title */}
+                <Text className="text-lg font-bold text-foreground mb-3" numberOfLines={2}>
+                    {props.title}
+                </Text>
+
+                {/* Meta row */}
+                <View className="flex-row items-center gap-4 mb-5">
+                    <View className="flex-row items-center">
+                        <BriefcaseBusiness size={14} color={mutedColor} />
+                        <Text className="text-sm text-muted-foreground ml-1.5">
+                            {JOBTYPES[props.jobType]}
+                        </Text>
+                    </View>
+                    <View className="flex-row items-center">
+                        <MapPin size={14} color={mutedColor} />
+                        <Text className="text-sm text-muted-foreground ml-1.5" numberOfLines={1}>
+                            {props.location}
+                        </Text>
+                    </View>
                 </View>
-                <View className="flex flex-row gap-2 ml-2 items-center">
-                    <Icon icon="CalendarClock" className="w-6 h-6 self-center stroke-1 dark:text-white" />
-                    <Text className="">{timeformat(new Date(props.deadline))}</Text>
-                </View>
+
+                {/* Divider */}
+                <View className="h-px bg-border dark:bg-muted" />
             </View>
         </View>
     )
@@ -62,28 +115,30 @@ export default function JobPostCard(props: JobPostProps) {
 
 export function JobPostCardSkeleton() {
     return (
-        <View className="w-full h-fit border-0 dark:border-2 dark:border-gray-800 rounded-lg bg-card dark:bg-[#020817]">
-            <View className="relative">
-                <View className="absolute left-0.5 top-0.5 bg-gray-900 px-3 py-1 rounded-lg z-50">
-                    <View className="m-1 h-2 w-16 bg-background rounded-md animate-pulse"></View>
+        <View className="pb-7">
+            {/* Image skeleton */}
+            <View className="w-full aspect-[2/1] bg-muted dark:bg-secondary/40 animate-pulse" />
+
+            {/* Content skeleton */}
+            <View className="px-4 pt-3.5">
+                {/* Header row */}
+                <View className="flex-row items-center justify-between mb-2">
+                    <View className="h-3.5 w-24 bg-muted dark:bg-secondary/40 rounded-md animate-pulse" />
+                    <View className="h-6 w-20 bg-muted dark:bg-secondary/40 rounded-full animate-pulse" />
                 </View>
-                <View className="animate-pulse bg-gray-300 aspect-[16/7] h-40 rounded-t-lg" />
-            </View>
-            <View className="w-full h-[1px] bg-gray-300 dark:bg-gray-950" />
-            <View className="flex flex-col gap-2 px-2 pb-4">
-                <View className="h-5 w-44 rounded-md bg-foreground opacity-25 mt-2 mb-2 animate-pulse"></View>
-                <View className="flex flex-row gap-2 ml-2">
-                    <Icon icon="BriefcaseBusiness" className="self-center stroke-1 dark:text-white" />
-                    <View className="h-2 w-24 bg-foreground opacity-25 animate-pulse rounded-sm self-center"></View>
+
+                {/* Title */}
+                <View className="h-5 w-3/4 bg-muted dark:bg-secondary/40 rounded-md animate-pulse mb-1.5" />
+                <View className="h-5 w-1/2 bg-muted dark:bg-secondary/40 rounded-md animate-pulse mb-3" />
+
+                {/* Meta row */}
+                <View className="flex-row items-center gap-4 mb-5">
+                    <View className="h-3.5 w-16 bg-muted dark:bg-secondary/40 rounded-md animate-pulse" />
+                    <View className="h-3.5 w-20 bg-muted dark:bg-secondary/40 rounded-md animate-pulse" />
                 </View>
-                <View className="flex flex-row gap-2 ml-2">
-                    <Icon icon="MapPin" className="self-center stroke-1 dark:text-white" />
-                    <View className="h-2 w-20 bg-foreground opacity-25 animate-pulse rounded-sm self-center"></View>
-                </View>
-                <View className="flex flex-row gap-2 ml-2">
-                    <Icon icon="CalendarClock" className="self-center stroke-1 dark:text-white" />
-                    <View className="h-2 w-28 bg-foreground opacity-25 animate-pulse rounded-sm self-center"></View>
-                </View>
+
+                {/* Divider */}
+                <View className="h-px bg-muted dark:bg-secondary/40" />
             </View>
         </View>
     )

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { View } from "react-native";
+import { Text } from "./text";
+import { cn } from "@/lib/utils";
+
+interface SectionHeaderProps {
+    title: string;
+    className?: string;
+}
+
+const SectionHeader = React.forwardRef<View, SectionHeaderProps>(
+    ({ title, className }, ref) => {
+        return (
+            <View ref={ref} className={cn("flex-row items-center mb-3", className)}>
+                <View className="w-1 h-5 rounded-full bg-primary dark:bg-accent mr-2.5" />
+                <Text className="text-lg font-semibold text-foreground">
+                    {title}
+                </Text>
+            </View>
+        );
+    }
+);
+
+SectionHeader.displayName = "SectionHeader";
+
+export { SectionHeader };


### PR DESCRIPTION
## Summary
- Redesigned career list page with full-width images, smart deadline badges (color-coded by urgency), and company/meta info rows
- Redesigned career detail page with grouped iOS-style detail rows, prominent apply button, and proper skeleton loading
- Created reusable `SectionHeader` component with primary-colored accent bar, used across career and profile pages
- Fixed back button text to show "Tilbake" consistently across karriere and profil navigation

Closes #93

## Test plan
- [x] Verify career list page renders correctly in light/dark mode
- [x] Verify career detail page layout and apply button works
- [ ] Check deadline badge colors: normal (blue), urgent ≤7 days (orange), expired (red)
- [ ] Confirm back button shows "Tilbake" on career detail and profile pages
- [ ] Test empty state when no job posts are available
- [ ] Test skeleton loading states on both list and detail pages
- [ ] Verify pull-to-refresh works on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)