### PR TITLE
fix: hent bruker og rettigheter der tokenet faktisk gjelder

### DIFF
--- a/actions/users/me.ts
+++ b/actions/users/me.ts
@@ -2,44 +2,102 @@ import { useQuery } from "@tanstack/react-query";
 import { apiJson } from "@/lib/api/client";
 import { ISSUER } from "@/lib/auth/photon";
 import { Event, Permissions, Membership, User } from "@/actions/types";
-import { PhotonGroup, PhotonUser, toMembership, toUser } from "@/actions/photon";
+import { PhotonGroup, toMembership, toUser } from "@/actions/photon";
 
-type PhotonSession = {
-    user: PhotonUser;
-    permissions: string[];
-    groups: { slug: string; name: string; type: string; logoUrl: string | null; role: string }[];
+/**
+ * Standardkravene fra OIDC-userinfo, pluss brukernavnet og rettighetene Photon
+ * legger på.
+ */
+type PhotonUserInfo = {
+    sub: string;
+    name?: string | null;
+    email?: string | null;
+    picture?: string | null;
+    preferred_username?: string | null;
+    permissions?: string[];
 };
 
 /**
- * Sesjonen dekker det Lepton delte på tre kall: /users/me/,
- * /users/me/permissions/ og /users/me/memberships/.
+ * Hvem tokenet tilhører, og hva det gir lov til.
+ *
+ * Access-tokenet er ikke alltid en JWT — plugin-en signerer bare når kallet har
+ * en audience, og gir ellers et opakt token uten krav i seg. Userinfo svarer
+ * likt uansett, så alt leses derfra.
  */
-async function session(): Promise<PhotonSession> {
-    return apiJson<PhotonSession>(`${ISSUER}/get-session`);
+function userinfo(): Promise<PhotonUserInfo> {
+    return apiJson<PhotonUserInfo>(`${ISSUER}/oauth2/userinfo`);
 }
 
+/** Delen av `/user/:id` appen viser. */
+type PhotonUserProfile = {
+    id: string;
+    name: string;
+    username: string | null;
+    image: string | null;
+    studyProgram: string | null;
+    studyStartYear: number | null;
+};
+
+/**
+ * Brukeren bak tokenet.
+ *
+ * Better Auth sin egen `/get-session` leser sesjonscookien, og en OAuth-klient
+ * har aldri noen cookie — den svarer `null` uansett hvor gyldig tokenet er.
+ * Identiteten hentes derfor fra OIDC-userinfo, og studieprogrammet fra Photons
+ * egen profilrute. Begge tar bearer-tokenet.
+ */
 export default async function me(): Promise<User> {
-    const data = await session();
-    return toUser(data.user);
+    const info = await userinfo();
+    const profile = await apiJson<PhotonUserProfile>(
+        `/user/${encodeURIComponent(info.sub)}`,
+    );
+
+    return toUser({
+        id: info.sub,
+        // Profilruta er kilden der begge har feltet: den foretrekker den
+        // opplastede avataren, mens userinfo alltid gir Feide-bildet.
+        name: profile.name ?? info.name,
+        username: profile.username ?? info.preferred_username,
+        // E-posten er privat i profilruta, så den kan bare komme herfra.
+        email: info.email,
+        image: profile.image ?? info.picture,
+        studyProgram: profile.studyProgram,
+        studyStartYear: profile.studyStartYear,
+    });
 }
 
 /**
  * Photons rettigheter er navngitte strenger med scope, ikke Leptons tabell
  * over Django-modeller med read/write per modell.
  *
- * Appen leser bare `event.write`, så oversettelsen dekker det den faktisk
- * bruker framfor å gjenskape en tabell ingen spør etter. Lesing er åpen for
- * innloggede i Photon, så `read` er sann når sesjonen finnes.
+ * Strengene kommer fra userinfo. En scopet rettighet ser ut som
+ * `events:update@group:sosialen`; her holder det å vite at brukeren har den et
+ * sted, siden API-et sjekker scopet på nytt når handlingen faktisk utføres.
+ *
+ * Appen leser bare `event.write` og `fine.write`, så oversettelsen dekker det
+ * den faktisk bruker framfor å gjenskape en tabell ingen spør etter. Lesing er
+ * åpen for innloggede i Photon, så `read` er sann når sesjonen finnes.
  */
 export async function myPermissions(): Promise<Permissions> {
-    const data = await session();
+    const { permissions } = await userinfo();
+    const granted = new Set(
+        (permissions ?? []).map((raw) => raw.split("@")[0]),
+    );
     const has = (...needles: string[]) =>
-        needles.some((needle) => data.permissions.includes(needle));
+        needles.some((needle) => granted.has(needle));
 
     return {
         event: {
             read: true,
-            write: has("events:manage", "events:create", "events:update"),
+            // Det eneste `event.write` styrer i appen er «Registrer oppmøte»,
+            // så innsjekksrettighetene teller like mye som redigering.
+            write: has(
+                "events:manage",
+                "events:create",
+                "events:update",
+                "events:registrations:manage",
+                "events:registrations:checkin",
+            ),
         },
         fine: {
             read: true,

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -192,7 +192,14 @@ export default function ArrangementSide() {
             <PageWrapper className="flex-1 bg-background">
                 <Stack.Screen options={{ title: "" }} />
                 <View className="flex-1 items-center justify-center px-6">
-                    <Text className="text-base text-destructive">{event.error?.message}</Text>
+                    {/* Begge spørringene kan feile hver for seg. Uten
+                        rettighetsfeilen her ble skjermen helt hvit når det var
+                        den som røk. */}
+                    <Text className="text-base text-destructive text-center">
+                        {event.error?.message ??
+                            permissions.error?.message ??
+                            "Kunne ikke laste arrangementet."}
+                    </Text>
                 </View>
             </PageWrapper>
         );

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -56,7 +56,12 @@ export default function Arrangementer() {
         if (debouncedSearch) queryParams.set('search', debouncedSearch);
         // Photon skiller kommende og tidligere med `expired`, og har egne
         // flagg for påmelding og favoritter under samme navn som før.
-        if (filters.expired) queryParams.set('expired', 'true');
+        //
+        // `expired` må alltid med: uten den blander Photon kommende og
+        // tidligere arrangementer i samme liste, sortert med det som ligger
+        // lengst fram i tid øverst. Med false kommer det som skjer først
+        // øverst, og med true de sist avholdte.
+        queryParams.set('expired', filters.expired ? 'true' : 'false');
         if (filters.openForSignUp) queryParams.set('openForSignUp', 'true');
         if (filters.userFavorite) queryParams.set('userFavorite', 'true');
 


### PR DESCRIPTION
Tre feil funnet ved testing av Photon-migreringen på simulator mot prod.

## 1. Sesjonen ble hentet fra feil endepunkt

`actions/users/me.ts` hentet bruker og rettigheter fra `${ISSUER}/get-session` — Better Auth sitt eget endepunkt, som bare leser sesjons**cookien**. En OAuth-klient har ingen cookie, så det svarte `200` med `null`. Profilskjermen viste feilen i klartekst: «Cannot read property 'user' of null». Alt som krever identitet var nede: profil, påmeldingsstatus, bøter og oppmøteregistrering.

Identiteten kommer nå fra OIDC-userinfo (`/oauth2/userinfo`) og studieprogrammet fra Photons `/user/:id`. Begge tar bearer-tokenet.

Rettighetene leses også fra userinfo, ikke fra tokenet: access-tokenet er bare en JWT når kallet har en audience, og opakt ellers. Krever [TIHLDE/Photon#475](https://github.com/TIHLDE/Photon/pull/475) for at feltet skal finnes — uten den er lista tom, og appen oppfører seg som for et vanlig medlem i stedet for å kræsje.

`event.write` styrer bare «Registrer oppmøte», så `events:registrations:checkin`/`:manage` teller nå like mye som redigeringsrettighetene.

## 2. Arrangementene lå i feil rekkefølge

`expired` ble bare sendt når «Tidligere»-filteret var på. Uten den blander Photon kommende og tidligere i samme liste, sortert med det som ligger lengst fram i tid øverst. Før: Vinmarathon 20. sep → Flammeblåserkurs 16. sep → Immatrikuleringsball 11. sep. Nå sendes `expired` alltid, og det som skjer først kommer øverst.

## 3. Hvit skjerm på arrangementssiden

Feilgrenen rendret bare `event.error?.message`. Når det var rettighetene som feilet ble teksten `undefined` og skjermen helt blank. Viser nå begge, med en fallback.

## Test

Verifisert på iPhone 17 Pro-simulator mot prod-Photon:

- Lista starter nå på nærmeste kommende arrangement (Silent Disco 22. aug.) i stedet for det fjerneste
- Arrangementssiden rendrer i stedet for hvit skjerm
- `npx tsc --noEmit`: 23 feil før og etter endringen — alle fra før, ingen i filene som er rørt

Profilskjermen og rettighetene gjenstår å verifisere: sesjonen i simulatoren gikk ut, og ny innlogging krever Feide-pålogging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)