### PR TITLE
feat: flytt profilen ned i bunnlinja

### DIFF
--- a/app/(app)/(tabs)/_layout.tsx
+++ b/app/(app)/(tabs)/_layout.tsx
@@ -17,6 +17,7 @@ export default function TabsLayout() {
 
     const isKarriere = pathname.includes("/karriere");
     const isArrangementer = pathname.includes("/arrangementer");
+    const isProfil = pathname.includes("/profil");
 
     return (
         <Tabs>
@@ -52,18 +53,6 @@ export default function TabsLayout() {
                     </View>
                 </TabTrigger>
 
-                {/* QR center button */}
-                <View style={styles.qrContainer}>
-                    <TouchableWithoutFeedback onPress={() => router.push('/(modals)/qrmodal')}>
-                        <View
-                            className="bg-primary dark:bg-accent items-center justify-center"
-                            style={styles.qrButton}
-                        >
-                            <QrCode className="color-white dark:color-background" size={26} />
-                        </View>
-                    </TouchableWithoutFeedback>
-                </View>
-
                 {/* Arrangementer tab */}
                 <TabTrigger name="arrangementer" href="/arrangementer" reset="never" style={styles.tabItem}>
                     <View className={`rounded-2xl py-1.5 items-center w-20 ${
@@ -86,6 +75,47 @@ export default function TabsLayout() {
                         </Text>
                     </View>
                 </TabTrigger>
+
+                {/* QR center button */}
+                <View style={styles.qrContainer}>
+                    <TouchableWithoutFeedback onPress={() => router.push('/(modals)/qrmodal')}>
+                        <View
+                            className="bg-primary dark:bg-accent items-center justify-center"
+                            style={styles.qrButton}
+                        >
+                            <QrCode className="color-white dark:color-background" size={26} />
+                        </View>
+                    </TouchableWithoutFeedback>
+                </View>
+
+                {/* Holder QR-knappen midtstilt: to plasser på hver side. */}
+                <View style={styles.tabItem} />
+
+                {/* Profil — ligger utenfor tab-navigatoren, så den dyttes på
+                    stacken som QR-knappen framfor å være en TabTrigger. */}
+                <View style={styles.tabItem}>
+                    <TouchableWithoutFeedback onPress={() => router.push('/profil')}>
+                        <View className={`rounded-2xl py-1.5 items-center w-20 ${
+                            isProfil ? "bg-primary/15 dark:bg-accent/20" : ""
+                        }`}>
+                            <Icon
+                                icon="UserRound"
+                                className={`self-center stroke-2 ${
+                                    isProfil
+                                        ? "color-primary dark:color-accent"
+                                        : "color-gray-400 dark:color-gray-500"
+                                }`}
+                            />
+                            <Text className={`text-[10px] mt-0.5 font-semibold ${
+                                isProfil
+                                    ? "color-primary dark:color-accent"
+                                    : "color-gray-400 dark:color-gray-500"
+                            }`}>
+                                Profil
+                            </Text>
+                        </View>
+                    </TouchableWithoutFeedback>
+                </View>
             </TabList>
         </Tabs>
     );

--- a/app/(app)/(tabs)/arrangementer/_layout.tsx
+++ b/app/(app)/(tabs)/arrangementer/_layout.tsx
@@ -1,11 +1,7 @@
-import Icon from "@/lib/icons/Icon";
 import FinesHeaderButton from "@/components/boter/FinesFAB";
-import { Stack, useRouter } from "expo-router";
-import { TouchableWithoutFeedback, View } from "react-native";
+import { Stack } from "expo-router";
 
 export default function ArrangementerLayout() {
-    const router = useRouter();
-
     return (
         <Stack>
             <Stack.Screen
@@ -14,16 +10,8 @@ export default function ArrangementerLayout() {
                     headerShown: true,
                     title: "Arrangementer",
                     headerTitleAlign: "center",
-                    headerRight: () => (
-                        <View className="flex-row items-center">
-                            <FinesHeaderButton />
-                            <TouchableWithoutFeedback onPressIn={() => router.push("/profil")}>
-                                <View className="w-10 h-10 items-center justify-center">
-                                    <Icon icon="UserRound" className="stroke-2 dark:text-white" />
-                                </View>
-                            </TouchableWithoutFeedback>
-                        </View>
-                    ),
+                    // Profilen ligger i bunnlinja; her står bare bøtene.
+                    headerRight: () => <FinesHeaderButton />,
                 }}
             />
         </Stack>

--- a/app/(app)/(tabs)/karriere/_layout.tsx
+++ b/app/(app)/(tabs)/karriere/_layout.tsx
@@ -1,11 +1,7 @@
-import { Stack, useRouter } from "expo-router";
-import { TouchableWithoutFeedback, View } from "react-native";
-import Icon from "@/lib/icons/Icon";
+import { Stack } from "expo-router";
 import FinesHeaderButton from "@/components/boter/FinesFAB";
 
 export default function KarriereLayout() {
-    const router = useRouter();
-
     return (
         <Stack
             screenOptions={{
@@ -19,16 +15,8 @@ export default function KarriereLayout() {
                     title: "Jobbannonser",
                     headerBackTitle: "Tilbake",
                     headerTitleAlign: "center",
-                    headerRight: () => (
-                        <View className="flex-row items-center">
-                            <FinesHeaderButton />
-                            <TouchableWithoutFeedback onPressIn={() => router.push("/profil")}>
-                                <View className="w-10 h-10 items-center justify-center">
-                                    <Icon icon="UserRound" className="stroke-2 dark:text-white" />
-                                </View>
-                            </TouchableWithoutFeedback>
-                        </View>
-                    ),
+                    // Profilen ligger i bunnlinja; her står bare bøtene.
+                    headerRight: () => <FinesHeaderButton />,
                 }}
             />
         </Stack>


### PR DESCRIPTION
Profilen lå oppe til høyre sammen med bøtene — to urelaterte ting i samme hjørne. Den hører hjemme i navigasjonen, så den flyttes helt til høyre i bunnlinja. Bøteknappen blir stående alene i headeren på både Arrangementer og Jobbannonser.

Profilsiden ligger utenfor tab-navigatoren (`app/(app)/profil/`), så knappen dytter på stacken slik QR-knappen gjør, framfor å være en `TabTrigger`. Arrangementer er flyttet til venstre for QR-knappen og en tom plass lagt inn til høyre, slik at QR-en fortsatt står midtstilt med to plasser på hver side.

## Test

`npx tsc --noEmit`: 23 feil før og etter — alle fra før, ingen i filene som er rørt.

Ikke visuelt verifisert ennå: sesjonen i simulatoren gikk ut, og bunnlinja vises bare for innloggede. Verifiseres ved neste innlogging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)