### PR TITLE
feat: bruk nettsidens farger, nøyaktig

### DIFF
--- a/app/(app)/(modals)/_layout.tsx
+++ b/app/(app)/(modals)/_layout.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Stack, useRouter } from 'expo-router';
 import { Pressable, View } from 'react-native';
 import { ChevronLeft } from 'lucide-react-native';
@@ -13,7 +14,7 @@ const modalScreenOptions = {
 export default function ModalsLayout() {
     const router = useRouter();
     const { isDarkColorScheme } = useColorScheme();
-    const backColor = isDarkColorScheme ? "#ffffff" : "#000000";
+    const backColor = themeColors(isDarkColorScheme).foreground;
 
     return (
         <Stack>

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { View, Image, ActivityIndicator, Pressable } from "react-native";
@@ -138,7 +139,7 @@ export default function ArrangementSide() {
     const bottomSheetModalRef = useRef<BottomSheetModal>(null);
     const unregisterSheetRef = useRef<BottomSheetModal>(null);
     const { isDarkColorScheme } = useColorScheme();
-    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const event = useQuery({
         queryKey: ["event", id],
@@ -235,7 +236,7 @@ export default function ArrangementSide() {
                 title: event.data.organizer?.name || '',
                 headerLeft: () => (
                     <Pressable onPress={() => router.back()} className="flex-row items-center -ml-2">
-                        <ChevronLeft size={28} color={isDarkColorScheme ? '#ffffff' : '#000000'} />
+                        <ChevronLeft size={28} color={themeColors(isDarkColorScheme).foreground} />
                         <Text className="text-[17px] text-foreground -ml-1">Tilbake</Text>
                     </Pressable>
                 ),
@@ -315,8 +316,8 @@ export default function ArrangementSide() {
                                 })}
                                 className="h-14 rounded-2xl bg-primary/10 dark:bg-primary/20 flex-row items-center justify-center mb-6 active:opacity-70"
                             >
-                                <ClipboardList size={18} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
-                                <Text className="text-base font-semibold text-primary dark:text-accent ml-2" style={{ fontFamily: "Inter" }}>
+                                <ClipboardList size={18} color={themeColors(isDarkColorScheme).primary} />
+                                <Text className="text-base font-semibold text-primary ml-2" style={{ fontFamily: "Inter" }}>
                                     Registrer oppmøte
                                 </Text>
                             </Pressable>
@@ -358,8 +359,8 @@ export default function ArrangementSide() {
                                     onPress={() => bottomSheetModalRef.current?.present()}
                                     className="flex-row items-center justify-center py-3 mb-2 active:opacity-70"
                                 >
-                                    <Icon icon="UserRound" className="color-primary dark:color-accent stroke-2" />
-                                    <Text className="text-sm font-semibold text-primary dark:text-accent ml-1.5" style={{ fontFamily: "Inter" }}>
+                                    <Icon icon="UserRound" className="color-primary stroke-2" />
+                                    <Text className="text-sm font-semibold text-primary ml-1.5" style={{ fontFamily: "Inter" }}>
                                         Se deltagerliste
                                     </Text>
                                 </Pressable>
@@ -472,7 +473,7 @@ function UnregisterDrawer({
             <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-6">
                 <View className="items-center py-4">
                     <View className="w-14 h-14 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-4">
-                        <CircleCheck size={26} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                        <CircleCheck size={26} color={themeColors(isDarkColorScheme).primary} />
                     </View>
                     <Text className="text-xl font-bold text-foreground text-center">
                         Avmeldt
@@ -489,7 +490,7 @@ function UnregisterDrawer({
         <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-6">
             <View className="items-center mb-4">
                 <View className="w-14 h-14 rounded-full bg-destructive/10 dark:bg-destructive/20 items-center justify-center mb-4">
-                    <TriangleAlert size={26} color={isDarkColorScheme ? '#f87171' : '#dc2626'} />
+                    <TriangleAlert size={26} color={themeColors(isDarkColorScheme).destructive} />
                 </View>
                 <Text className="text-xl font-bold text-foreground text-center">
                     Meld deg av?
@@ -624,6 +625,7 @@ function RegistrationButton({
     mutationPending?: boolean;
     unregisterSheetRef: React.RefObject<BottomSheetModal | null>;
 }) {
+    const { isDarkColorScheme } = useColorScheme();
     const user = useQuery({
         queryKey: ["users", "me"],
         queryFn: me,
@@ -705,11 +707,13 @@ function RegistrationButton({
         );
     }
 
+    const palette = themeColors(isDarkColorScheme);
+
     const statusBannerStyles: Record<string, { bg: string; iconColor: string; textColor: string }> = {
-        success: { bg: 'bg-primary/10 dark:bg-primary/20', iconColor: '#2d5dab', textColor: 'text-primary dark:text-accent' },
+        success: { bg: 'bg-primary/10 dark:bg-primary/20', iconColor: palette.primary, textColor: 'text-primary' },
         info: { bg: 'bg-orange-100 dark:bg-orange-500/20', iconColor: '#ea580c', textColor: 'text-orange-600 dark:text-orange-400' },
         warning: { bg: 'bg-orange-100 dark:bg-orange-500/20', iconColor: '#ea580c', textColor: 'text-orange-600 dark:text-orange-400' },
-        error: { bg: 'bg-destructive/10 dark:bg-destructive/20', iconColor: '#dc2626', textColor: 'text-destructive' },
+        error: { bg: 'bg-destructive/10 dark:bg-destructive/20', iconColor: palette.destructive, textColor: 'text-destructive' },
     };
 
     const statusIcon: Record<string, React.ReactNode> = {
@@ -759,7 +763,8 @@ function RegistrationButton({
                             <ActivityIndicator />
                         ) : (
                             <>
-                                <LogOut size={18} color={isDisabled ? '#f8717180' : '#dc2626'} />
+                                {/* 80 = 50 % opacity, samme dempning som teksten ved siden av. */}
+                                <LogOut size={18} color={isDisabled ? `${palette.destructive}80` : palette.destructive} />
                                 <Text className={`text-base font-semibold ml-2 ${isDisabled ? 'text-destructive/50' : 'text-destructive'}`} style={{ fontFamily: "Inter" }}>
                                     {buttonText}
                                 </Text>
@@ -772,7 +777,7 @@ function RegistrationButton({
                         onPress={() => onClick?.()}
                         disabled={isDisabled || mutationPending}
                         className={`h-14 rounded-2xl flex-row items-center justify-center mb-2 active:opacity-80 ${
-                            isDisabled ? 'bg-primary/40 dark:bg-primary/30' : 'bg-primary dark:bg-[#1C5ECA]'
+                            isDisabled ? 'bg-primary/40 dark:bg-primary/30' : 'bg-primary'
                         }`}
                     >
                         {mutationPending ? (
@@ -822,7 +827,7 @@ function PaymentButton({ eventId }: { eventId: string }) {
             }}
             disabled={payment.isPending}
             className={`h-14 rounded-2xl flex-row items-center justify-center mb-4 active:opacity-80 ${
-                payment.isPending ? 'bg-primary/40 dark:bg-primary/30' : 'bg-primary dark:bg-[#1C5ECA]'
+                payment.isPending ? 'bg-primary/40 dark:bg-primary/30' : 'bg-primary'
             }`}
         >
             {payment.isPending ? (

--- a/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import { ActivityIndicator, FlatList, Pressable, TextInput, View } from "react-native";
 import { CameraView, useCameraPermissions } from 'expo-camera';
@@ -91,7 +92,7 @@ function CameraRegistration({ cameraDisabled = false }: { cameraDisabled?: boole
         return (
             <View className="flex-1 items-center justify-center px-8">
                 <View className="w-20 h-20 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-6">
-                    <Camera size={36} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                    <Camera size={36} color={themeColors(isDarkColorScheme).primary} />
                 </View>
                 <Text className="text-xl font-bold text-foreground text-center mb-2">
                     Kameratilgang
@@ -101,7 +102,7 @@ function CameraRegistration({ cameraDisabled = false }: { cameraDisabled?: boole
                 </Text>
                 <Pressable
                     onPress={requestPermission}
-                    className="h-14 rounded-2xl bg-primary dark:bg-[#1C5ECA] px-8 flex-row items-center justify-center active:opacity-80"
+                    className="h-14 rounded-2xl bg-primary px-8 flex-row items-center justify-center active:opacity-80"
                 >
                     <Camera size={18} color="white" />
                     <Text className="text-white text-base font-semibold ml-2" style={{ fontFamily: "Inter" }}>
@@ -116,7 +117,7 @@ function CameraRegistration({ cameraDisabled = false }: { cameraDisabled?: boole
         return (
             <View className="flex-1 items-center justify-center px-8">
                 <View className="w-20 h-20 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-6">
-                    <Camera size={36} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                    <Camera size={36} color={themeColors(isDarkColorScheme).primary} />
                 </View>
                 <Text className="text-xl font-bold text-foreground text-center mb-2">
                     Kameratilgang kreves
@@ -188,7 +189,7 @@ function CameraRegistration({ cameraDisabled = false }: { cameraDisabled?: boole
                         <>
                             <View className="items-center mb-4">
                                 <View className="w-14 h-14 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-4">
-                                    <UserCheck size={26} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                                    <UserCheck size={26} color={themeColors(isDarkColorScheme).primary} />
                                 </View>
                                 <Text className="text-xl font-bold text-foreground text-center">
                                     Registrer oppmøte
@@ -202,7 +203,7 @@ function CameraRegistration({ cameraDisabled = false }: { cameraDisabled?: boole
                                     onPress={() => {
                                         updateRegistrationMutation.mutate({ newValue: true, userId: userToRegister?.user_id ?? "" });
                                     }}
-                                    className="h-14 rounded-2xl bg-primary dark:bg-[#1C5ECA] items-center justify-center active:opacity-80"
+                                    className="h-14 rounded-2xl bg-primary items-center justify-center active:opacity-80"
                                 >
                                     <Text className="text-white text-base font-semibold" style={{ fontFamily: "Inter" }}>
                                         Registrer
@@ -232,7 +233,7 @@ function ManualRegistration() {
     const [searchText, setSearchText] = useState('');
     const debouncedSearch = useDebounce(searchText, 500);
 
-    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const {
         data,
@@ -373,7 +374,7 @@ function EventRegistration({ registration, eventId }: { registration: Registrati
             className="flex-row items-center py-3.5 active:opacity-70"
         >
             <View className="w-10 h-10 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center mr-3">
-                <Text className="text-sm font-bold text-primary dark:text-accent">
+                <Text className="text-sm font-bold text-primary">
                     {initials}
                 </Text>
             </View>

--- a/app/(app)/(modals)/boter/[groupSlug]/bekreft.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/bekreft.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import PageWrapper from "@/components/ui/pagewrapper";
 import { useColorScheme } from "@/lib/useColorScheme";
@@ -34,7 +35,7 @@ type SelectedUser = {
 export default function ConfirmFine() {
     const router = useRouter();
     const { isDarkColorScheme } = useColorScheme();
-    const mutedColor = isDarkColorScheme ? "#9ca3af" : "#6b7280";
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const {
         groupSlug,
@@ -154,7 +155,7 @@ export default function ConfirmFine() {
                     </Text>
                     <Pressable
                         onPress={goBackToStart}
-                        className="h-14 rounded-2xl bg-primary dark:bg-[#1C5ECA] items-center justify-center px-8 active:opacity-80"
+                        className="h-14 rounded-2xl bg-primary items-center justify-center px-8 active:opacity-80"
                     >
                         <Text
                             className="text-white text-base font-semibold"
@@ -177,7 +178,7 @@ export default function ConfirmFine() {
             >
                 {/* Law summary */}
                 <View className="mx-4 mt-4 bg-primary/10 dark:bg-primary/20 rounded-2xl p-4">
-                    <Text className="text-sm font-semibold text-primary dark:text-accent">
+                    <Text className="text-sm font-semibold text-primary">
                         §{lawParagraph} — {lawTitle}
                     </Text>
                     <Text className="text-sm text-muted-foreground mt-1">
@@ -208,7 +209,7 @@ export default function ConfirmFine() {
                                         />
                                     ) : (
                                         <View className="w-12 h-12 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
-                                            <Text className="text-sm font-bold text-primary dark:text-accent">
+                                            <Text className="text-sm font-bold text-primary">
                                                 {user.first_name[0]}
                                                 {user.last_name[0]}
                                             </Text>
@@ -327,7 +328,7 @@ export default function ConfirmFine() {
                     disabled={!reason.trim() || isSubmitting}
                     className={`h-14 rounded-2xl flex-row items-center justify-center ${
                         reason.trim() && !isSubmitting
-                            ? "bg-primary dark:bg-[#1C5ECA] active:opacity-80"
+                            ? "bg-primary active:opacity-80"
                             : "bg-gray-200 dark:bg-secondary/30"
                     }`}
                 >

--- a/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import PageWrapper from "@/components/ui/pagewrapper";
 import { useColorScheme } from "@/lib/useColorScheme";
@@ -47,7 +48,7 @@ export default function UserSelection() {
     }>();
 
     const { isDarkColorScheme } = useColorScheme();
-    const mutedColor = isDarkColorScheme ? "#9ca3af" : "#6b7280";
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const [searchText, setSearchText] = useState("");
     const [selectedUsers, setSelectedUsers] = useState<GroupUser[]>([]);
@@ -169,7 +170,7 @@ export default function UserSelection() {
                                 />
                             ) : (
                                 <View className="w-10 h-10 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
-                                    <Text className="text-sm font-bold text-primary dark:text-accent">
+                                    <Text className="text-sm font-bold text-primary">
                                         {user.first_name[0]}
                                         {user.last_name[0]}
                                     </Text>
@@ -179,7 +180,7 @@ export default function UserSelection() {
                                 {user.first_name} {user.last_name}
                             </Text>
                             {selected && (
-                                <View className="w-7 h-7 rounded-full bg-primary dark:bg-[#1C5ECA] items-center justify-center">
+                                <View className="w-7 h-7 rounded-full bg-primary items-center justify-center">
                                     <Check size={16} color="white" />
                                 </View>
                             )}
@@ -221,7 +222,7 @@ export default function UserSelection() {
                     disabled={selectedUsers.length === 0}
                     className={`h-14 rounded-2xl flex-row items-center justify-center ${
                         selectedUsers.length > 0
-                            ? "bg-primary dark:bg-[#1C5ECA] active:opacity-80"
+                            ? "bg-primary active:opacity-80"
                             : "bg-gray-200 dark:bg-secondary/30"
                     }`}
                 >

--- a/app/(app)/(modals)/boter/[groupSlug]/index.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/index.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import PageWrapper from "@/components/ui/pagewrapper";
 import useRefresh from "@/lib/useRefresh";
@@ -24,7 +25,7 @@ export default function LawSelection() {
     const router = useRouter();
     const { groupSlug } = useLocalSearchParams<{ groupSlug: string }>();
     const { isDarkColorScheme } = useColorScheme();
-    const mutedColor = isDarkColorScheme ? "#9ca3af" : "#6b7280";
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const laws = useQuery({
         queryKey: ["laws", groupSlug],
@@ -59,7 +60,7 @@ export default function LawSelection() {
                         className="mx-4 mb-3 bg-gray-100 dark:bg-secondary/30 rounded-2xl p-4 flex-row items-center active:opacity-70"
                     >
                         <View className="w-12 h-12 rounded-xl bg-primary/10 dark:bg-primary/20 items-center justify-center">
-                            <Text className="text-sm font-bold text-primary dark:text-accent">
+                            <Text className="text-sm font-bold text-primary">
                                 §{law.paragraph}
                             </Text>
                         </View>
@@ -76,7 +77,7 @@ export default function LawSelection() {
                         </View>
                         <View className="items-center">
                             <View className="bg-primary/10 dark:bg-primary/20 rounded-full px-2.5 py-1 mb-1">
-                                <Text className="text-xs font-semibold text-primary dark:text-accent">
+                                <Text className="text-xs font-semibold text-primary">
                                     {law.amount}{" "}
                                     {law.amount === 1 ? "bot" : "bøter"}
                                 </Text>
@@ -104,7 +105,7 @@ export default function LawSelection() {
                                 <Scale
                                     size={28}
                                     color={
-                                        isDarkColorScheme ? "#8ba3d4" : "#2d5dab"
+                                        themeColors(isDarkColorScheme).primary
                                     }
                                 />
                             </View>

--- a/app/(app)/(modals)/boter/index.tsx
+++ b/app/(app)/(modals)/boter/index.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import PageWrapper from "@/components/ui/pagewrapper";
 import useRefresh from "@/lib/useRefresh";
@@ -24,7 +25,7 @@ function MembershipCardSkeleton() {
 export default function MembershipSelection() {
     const router = useRouter();
     const { isDarkColorScheme } = useColorScheme();
-    const mutedColor = isDarkColorScheme ? "#9ca3af" : "#6b7280";
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const memberships = useQuery({
         queryKey: ["memberships"],
@@ -61,7 +62,7 @@ export default function MembershipSelection() {
                                 <Users
                                     size={20}
                                     color={
-                                        isDarkColorScheme ? "#8ba3d4" : "#2d5dab"
+                                        themeColors(isDarkColorScheme).primary
                                     }
                                 />
                             </View>
@@ -98,7 +99,7 @@ export default function MembershipSelection() {
                                 <Users
                                     size={28}
                                     color={
-                                        isDarkColorScheme ? "#8ba3d4" : "#2d5dab"
+                                        themeColors(isDarkColorScheme).primary
                                     }
                                 />
                             </View>

--- a/app/(app)/(tabs)/_layout.tsx
+++ b/app/(app)/(tabs)/_layout.tsx
@@ -33,19 +33,19 @@ export default function TabsLayout() {
                 {/* Karriere tab */}
                 <TabTrigger name="karriere" href="/karriere" reset="never" style={styles.tabItem}>
                     <View className={`rounded-2xl py-1.5 items-center w-20 ${
-                        isKarriere ? "bg-primary/15 dark:bg-accent/20" : ""
+                        isKarriere ? "bg-primary/15" : ""
                     }`}>
                         <Icon
                             icon="BriefcaseBusiness"
                             className={`self-center stroke-2 ${
                                 isKarriere
-                                    ? "color-primary dark:color-accent"
+                                    ? "color-primary"
                                     : "color-gray-400 dark:color-gray-500"
                             }`}
                         />
                         <Text className={`text-[10px] mt-0.5 font-semibold ${
                             isKarriere
-                                ? "color-primary dark:color-accent"
+                                ? "color-primary"
                                 : "color-gray-400 dark:color-gray-500"
                         }`}>
                             Karriere
@@ -56,19 +56,19 @@ export default function TabsLayout() {
                 {/* Arrangementer tab */}
                 <TabTrigger name="arrangementer" href="/arrangementer" reset="never" style={styles.tabItem}>
                     <View className={`rounded-2xl py-1.5 items-center w-20 ${
-                        isArrangementer ? "bg-primary/15 dark:bg-accent/20" : ""
+                        isArrangementer ? "bg-primary/15" : ""
                     }`}>
                         <Icon
                             icon="Calendar"
                             className={`self-center stroke-2 ${
                                 isArrangementer
-                                    ? "color-primary dark:color-accent"
+                                    ? "color-primary"
                                     : "color-gray-400 dark:color-gray-500"
                             }`}
                         />
                         <Text className={`text-[10px] mt-0.5 font-semibold ${
                             isArrangementer
-                                ? "color-primary dark:color-accent"
+                                ? "color-primary"
                                 : "color-gray-400 dark:color-gray-500"
                         }`}>
                             Events
@@ -80,7 +80,7 @@ export default function TabsLayout() {
                 <View style={styles.qrContainer}>
                     <TouchableWithoutFeedback onPress={() => router.push('/(modals)/qrmodal')}>
                         <View
-                            className="bg-primary dark:bg-accent items-center justify-center"
+                            className="bg-primary items-center justify-center"
                             style={styles.qrButton}
                         >
                             <QrCode className="color-white dark:color-background" size={26} />
@@ -96,19 +96,19 @@ export default function TabsLayout() {
                 <View style={styles.tabItem}>
                     <TouchableWithoutFeedback onPress={() => router.push('/profil')}>
                         <View className={`rounded-2xl py-1.5 items-center w-20 ${
-                            isProfil ? "bg-primary/15 dark:bg-accent/20" : ""
+                            isProfil ? "bg-primary/15" : ""
                         }`}>
                             <Icon
                                 icon="UserRound"
                                 className={`self-center stroke-2 ${
                                     isProfil
-                                        ? "color-primary dark:color-accent"
+                                        ? "color-primary"
                                         : "color-gray-400 dark:color-gray-500"
                                 }`}
                             />
                             <Text className={`text-[10px] mt-0.5 font-semibold ${
                                 isProfil
-                                    ? "color-primary dark:color-accent"
+                                    ? "color-primary"
                                     : "color-gray-400 dark:color-gray-500"
                             }`}>
                                 Profil

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import EventCard, { EventCardSkeleton } from "@/components/arrangement/eventCard";
 import { Text } from "@/components/ui/text";
 import { router, Stack } from "expo-router";
@@ -96,7 +97,7 @@ export default function Arrangementer() {
         return page.results;
     }) ?? [];
 
-    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const handleApplyFilters = () => {
         filterSheetRef.current?.dismiss();
@@ -117,7 +118,7 @@ export default function Arrangementer() {
                             className="w-10 h-10 items-center justify-center"
                         >
                             <View>
-                                <SlidersHorizontal size={20} color={isDarkColorScheme ? '#ffffff' : '#000000'} />
+                                <SlidersHorizontal size={20} color={themeColors(isDarkColorScheme).foreground} />
                                 {activeFilterCount > 0 && (
                                     <View className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-primary items-center justify-center">
                                         <Text className="text-[10px] font-bold text-white">{activeFilterCount}</Text>
@@ -169,10 +170,10 @@ export default function Arrangementer() {
                                             onPress={() => setSearchText('')}
                                             className="flex-row items-center bg-primary/10 dark:bg-primary/20 rounded-full px-3 py-1.5"
                                         >
-                                            <Text className="text-xs font-semibold text-primary dark:text-accent mr-1.5" style={{ fontFamily: "Inter" }}>
+                                            <Text className="text-xs font-semibold text-primary mr-1.5" style={{ fontFamily: "Inter" }}>
                                                 &ldquo;{debouncedSearch}&rdquo;
                                             </Text>
-                                            <X size={12} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                                            <X size={12} color={themeColors(isDarkColorScheme).primary} />
                                         </Pressable>
                                     ) : null}
                                     {filters.expired && (
@@ -180,10 +181,10 @@ export default function Arrangementer() {
                                             onPress={() => setFilters(f => ({ ...f, expired: false }))}
                                             className="flex-row items-center bg-primary/10 dark:bg-primary/20 rounded-full px-3 py-1.5"
                                         >
-                                            <Text className="text-xs font-semibold text-primary dark:text-accent mr-1.5" style={{ fontFamily: "Inter" }}>
+                                            <Text className="text-xs font-semibold text-primary mr-1.5" style={{ fontFamily: "Inter" }}>
                                                 Tidligere
                                             </Text>
-                                            <X size={12} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                                            <X size={12} color={themeColors(isDarkColorScheme).primary} />
                                         </Pressable>
                                     )}
                                     {filters.openForSignUp && (
@@ -191,10 +192,10 @@ export default function Arrangementer() {
                                             onPress={() => setFilters(f => ({ ...f, openForSignUp: false }))}
                                             className="flex-row items-center bg-primary/10 dark:bg-primary/20 rounded-full px-3 py-1.5"
                                         >
-                                            <Text className="text-xs font-semibold text-primary dark:text-accent mr-1.5" style={{ fontFamily: "Inter" }}>
+                                            <Text className="text-xs font-semibold text-primary mr-1.5" style={{ fontFamily: "Inter" }}>
                                                 Åpen påmelding
                                             </Text>
-                                            <X size={12} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                                            <X size={12} color={themeColors(isDarkColorScheme).primary} />
                                         </Pressable>
                                     )}
                                     {filters.userFavorite && (
@@ -202,10 +203,10 @@ export default function Arrangementer() {
                                             onPress={() => setFilters(f => ({ ...f, userFavorite: false }))}
                                             className="flex-row items-center bg-primary/10 dark:bg-primary/20 rounded-full px-3 py-1.5"
                                         >
-                                            <Text className="text-xs font-semibold text-primary dark:text-accent mr-1.5" style={{ fontFamily: "Inter" }}>
+                                            <Text className="text-xs font-semibold text-primary mr-1.5" style={{ fontFamily: "Inter" }}>
                                                 Favoritter
                                             </Text>
-                                            <X size={12} color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'} />
+                                            <X size={12} color={themeColors(isDarkColorScheme).primary} />
                                         </Pressable>
                                     )}
                                 </View>
@@ -246,7 +247,7 @@ export default function Arrangementer() {
                                 <View className="w-16 h-16 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-4">
                                     <CalendarDays
                                         size={28}
-                                        color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'}
+                                        color={themeColors(isDarkColorScheme).primary}
                                     />
                                 </View>
                                 <Text className="text-lg font-semibold text-foreground mb-1">
@@ -289,7 +290,7 @@ export default function Arrangementer() {
                                 <Text className="text-xl font-bold text-foreground">Filter</Text>
                                 {activeFilterCount > 0 && (
                                     <View className="ml-2.5 w-6 h-6 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
-                                        <Text className="text-xs font-bold text-primary dark:text-accent">
+                                        <Text className="text-xs font-bold text-primary">
                                             {activeFilterCount}
                                         </Text>
                                     </View>
@@ -358,7 +359,7 @@ export default function Arrangementer() {
                         {/* Apply button */}
                         <Pressable
                             onPress={handleApplyFilters}
-                            className="h-14 rounded-2xl bg-primary dark:bg-[#1C5ECA] flex-row items-center justify-center active:opacity-80"
+                            className="h-14 rounded-2xl bg-primary flex-row items-center justify-center active:opacity-80"
                         >
                             <Search size={16} color="white" />
                             <Text className="text-white text-base font-semibold ml-2" style={{ fontFamily: "Inter" }}>

--- a/app/(app)/(tabs)/karriere/[karriereId].tsx
+++ b/app/(app)/(tabs)/karriere/[karriereId].tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { JOBTYPES } from "@/components/karriere/jobpostcard";
 import { Text } from "@/components/ui/text";
 import { useQuery } from "@tanstack/react-query";
@@ -105,7 +106,7 @@ export default function Karriereside() {
     });
 
     const refreshControl = useRefresh(["jobpost", id as string]);
-    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     if (jobpost.isPending) return (
         <>
@@ -208,7 +209,7 @@ export default function Karriereside() {
                         {jobpost.data.link && (
                             <Pressable
                                 onPress={handleApply}
-                                className="h-14 rounded-2xl bg-primary dark:bg-[#1C5ECA] flex-row items-center justify-center mb-8 active:opacity-80"
+                                className="h-14 rounded-2xl bg-primary flex-row items-center justify-center mb-8 active:opacity-80"
                             >
                                 <Text
                                     className="text-white text-base font-semibold mr-2"

--- a/app/(app)/(tabs)/karriere/index.tsx
+++ b/app/(app)/(tabs)/karriere/index.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { fetchJobPosts } from "@/actions/events/events";
 import JobPostCard, { JobPostCardSkeleton } from "@/components/karriere/jobpostcard";
 import PageWrapper from "@/components/ui/pagewrapper";
@@ -78,7 +79,7 @@ export default function Karriere() {
                             <View className="w-16 h-16 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-4">
                                 <BriefcaseBusiness
                                     size={28}
-                                    color={isDarkColorScheme ? '#8ba3d4' : '#2d5dab'}
+                                    color={themeColors(isDarkColorScheme).primary}
                                 />
                             </View>
                             <Text className="text-lg font-semibold text-foreground mb-1">

--- a/app/(app)/profil/index.tsx
+++ b/app/(app)/profil/index.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import me, { myEvents } from "@/actions/users/me";
 import PageWrapper from "@/components/ui/pagewrapper";
 import { Text } from "@/components/ui/text";
@@ -39,7 +40,7 @@ export default function Profil() {
     const refreshControl = useRefresh(["users", "me"]);
 
 
-    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     if (user.isPending) {
         return (
@@ -104,7 +105,7 @@ export default function Profil() {
                             />
                         ) : (
                             <View className="w-28 h-28 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
-                                <Text className="text-3xl font-bold text-primary dark:text-accent">
+                                <Text className="text-3xl font-bold text-primary">
                                     {initials}
                                 </Text>
                             </View>
@@ -153,7 +154,7 @@ export default function Profil() {
                             onPress={() => logoutSheetRef.current?.present()}
                             className="flex-row items-center justify-center h-14 rounded-2xl bg-destructive/10 dark:bg-destructive/20 active:opacity-70"
                         >
-                            <LogOut size={18} color={isDarkColorScheme ? '#f87171' : '#dc2626'} />
+                            <LogOut size={18} color={themeColors(isDarkColorScheme).destructive} />
                             <Text className="text-base font-semibold text-destructive ml-2">
                                 Logg ut
                             </Text>
@@ -174,7 +175,7 @@ export default function Profil() {
                         <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-6">
                             <View className="items-center mb-4">
                                 <View className="w-14 h-14 rounded-full bg-destructive/10 dark:bg-destructive/20 items-center justify-center mb-4">
-                                    <TriangleAlert size={26} color={isDarkColorScheme ? '#f87171' : '#dc2626'} />
+                                    <TriangleAlert size={26} color={themeColors(isDarkColorScheme).destructive} />
                                 </View>
                                 <Text className="text-xl font-bold text-foreground text-center">
                                     Logg ut

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -84,7 +84,7 @@ export default function Login() {
                                 "h-14 rounded-2xl items-center justify-center",
                                 isPending
                                     ? "bg-primary/40 dark:bg-primary/30"
-                                    : "bg-primary dark:bg-[#1C5ECA] active:opacity-80"
+                                    : "bg-primary active:opacity-80"
                             )}
                         >
                             {isPending ? (
@@ -105,7 +105,7 @@ export default function Login() {
                                 onPress={_handlePressButtonForgotPasswordAsync}
                                 hitSlop={8}
                             >
-                                <Text className="text-sm text-primary dark:text-accent">
+                                <Text className="text-sm text-primary">
                                     Glemt passord?
                                 </Text>
                             </Pressable>
@@ -120,7 +120,7 @@ export default function Login() {
                                 onPress={_handlePressButtonCreateUserAsync}
                                 hitSlop={8}
                             >
-                                <Text className="text-sm font-semibold text-primary dark:text-accent">
+                                <Text className="text-sm font-semibold text-primary">
                                     Opprett bruker
                                 </Text>
                             </Pressable>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -3,6 +3,7 @@ import { Redirect } from "expo-router";
 import { useEffect, useState } from "react";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import Svg, { Rect, G, Mask, Path, Defs, ClipPath } from "react-native-svg";
+import { themeColors } from "@/lib/theme/colors";
 
 
 export default function Arrangementer() {
@@ -29,8 +30,10 @@ export default function Arrangementer() {
     if (showLoading) {
         return (
             <SafeAreaProvider>
+                {/* Splashen er mørk uansett tema — logoen i den er hvit. */}
                 <SafeAreaView
-                    className="flex-1 justify-center items-center bg-[#001329]"
+                    className="flex-1 justify-center items-center"
+                    style={{ backgroundColor: themeColors(true).background }}
                 >
                     <SplashLogo />
                 </SafeAreaView>
@@ -55,7 +58,7 @@ function SplashLogo() {
             height={852}
             viewBox="0 0 393 852"
             fill="none">
-            <Rect width={393} height={852} fill="#001329" />
+            <Rect width={393} height={852} fill={themeColors(true).background} />
             <G clipPath="url(#clip0_167_297)">
                 <Mask
                     id="mask0_167_297"

--- a/components/arrangement/eventCard.tsx
+++ b/components/arrangement/eventCard.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import React from 'react';
 import { View, Image, Pressable } from 'react-native';
 import { Text } from "@/components/ui/text";
@@ -32,7 +33,7 @@ function OrganizerBadge({ organizer }: { organizer: EventCardProps['organizer'] 
         plask: { bg: 'bg-purple-100 dark:bg-purple-500/20', text: 'text-purple-600 dark:text-purple-400' },
     };
 
-    const colors = colorMap[slug ?? ''] ?? { bg: 'bg-primary/10 dark:bg-primary/20', text: 'text-primary dark:text-accent' };
+    const colors = colorMap[slug ?? ''] ?? { bg: 'bg-primary/10 dark:bg-primary/20', text: 'text-primary' };
 
     return (
         <View className={`px-3 py-1 rounded-full ${colors.bg}`}>
@@ -52,7 +53,7 @@ const EventCard = ({
     location,
 }: EventCardProps) => {
     const { isDarkColorScheme } = useColorScheme();
-    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     const dateObj = date
         ? typeof date === "string" ? new Date(date) : date

--- a/components/boter/FinesFAB.tsx
+++ b/components/boter/FinesFAB.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import React from "react";
 import { Pressable, View } from "react-native";
 import { Gavel } from "lucide-react-native";
@@ -15,7 +16,7 @@ export default function FinesHeaderButton() {
         >
             {({ pressed }) => (
                 <View style={{ opacity: pressed ? 0.7 : 1 }}>
-                    <Gavel size={22} strokeWidth={2} color={isDarkColorScheme ? "#ffffff" : "#000000"} />
+                    <Gavel size={22} strokeWidth={2} color={themeColors(isDarkColorScheme).foreground} />
                 </View>
             )}
         </Pressable>

--- a/components/karriere/jobpostcard.tsx
+++ b/components/karriere/jobpostcard.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { Image, View } from "react-native";
 import { Text } from "../ui/text";
 import { BriefcaseBusiness, MapPin, Building2 } from "lucide-react-native";
@@ -45,7 +46,7 @@ function DeadlineBadge({ deadline }: { deadline: string }) {
                     ? 'text-destructive'
                     : isUrgent
                         ? 'text-orange-600 dark:text-orange-400'
-                        : 'text-primary dark:text-accent'
+                        : 'text-primary'
             }`} style={{ fontFamily: "Inter" }}>
                 {isPast ? 'Utløpt' : `Frist ${formatted}`}
             </Text>
@@ -55,7 +56,7 @@ function DeadlineBadge({ deadline }: { deadline: string }) {
 
 export default function JobPostCard(props: JobPostProps) {
     const { isDarkColorScheme } = useColorScheme();
-    const mutedColor = isDarkColorScheme ? '#9ca3af' : '#6b7280';
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
 
     return (
         <View className="pb-7">

--- a/components/ui/AnimatedPagerView.tsx
+++ b/components/ui/AnimatedPagerView.tsx
@@ -24,7 +24,7 @@ export default function AnimatedPagerView(props: AnimatedPagerViewProps) {
                     const isActive = activeIndex === index;
                     return (
                         <Pressable
-                            className={`flex-1 py-2.5 rounded-xl items-center justify-center ${isActive ? 'bg-primary dark:bg-[#1C5ECA]' : ''}`}
+                            className={`flex-1 py-2.5 rounded-xl items-center justify-center ${isActive ? 'bg-primary' : ''}`}
                             key={index}
                             onPress={() => requestAnimationFrame(() => pagerViewRef.current?.setPage(index))}
                         >

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary dark:bg-[#1C5ECA] web:hover:opacity-90 active:opacity-90',
+        default: 'bg-primary web:hover:opacity-90 active:opacity-90',
         destructive: 'bg-destructive web:hover:opacity-90 active:opacity-90',
         outline:
           'border border-input bg-background web:hover:bg-accent web:hover:text-accent-foreground active:bg-accent',

--- a/components/ui/floating-label-input.tsx
+++ b/components/ui/floating-label-input.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import React, {useState, useRef, useEffect, type ReactNode} from 'react';
 import {TextInput, View, Pressable, type TextInputProps} from 'react-native';
 import Animated, {
@@ -36,15 +37,18 @@ const FloatingLabelInput = React.forwardRef<TextInput, FloatingLabelInputProps>(
             progress.value = withTiming(isActive ? 1 : 0, {duration: DURATION});
         }, [isFocused, value]);
 
+        // Hentes ut som vanlige strenger her, ikke inne i worklet-ene under:
+        // de kjører på UI-tråden og fanger bare verdier.
+        const { primary, mutedForeground, input, card, foreground } =
+            themeColors(isDarkColorScheme);
+
         const labelStyle = useAnimatedStyle(() => {
             const top = interpolate(progress.value, [0, 1], [17, -10]);
             const fontSize = interpolate(progress.value, [0, 1], [16, 12]);
             const color = interpolateColor(
                 progress.value,
                 [0, 1],
-                isDarkColorScheme
-                    ? ['#9ca3af', '#8ba3d4']
-                    : ['#9ca3af', '#2d5dab']
+                [mutedForeground, primary]
             );
 
             return {
@@ -63,17 +67,15 @@ const FloatingLabelInput = React.forwardRef<TextInput, FloatingLabelInputProps>(
             const borderColor = interpolateColor(
                 progress.value,
                 [0, 1],
-                isDarkColorScheme
-                    ? ['#6b7280', '#8ba3d4']
-                    : ['#d1d5db', '#2d5dab']
+                [input, primary]
             );
 
             return {borderColor};
         });
 
-        const iconColor = isDarkColorScheme ? '#8ba3d4' : '#2d5dab';
+        const iconColor = primary;
 
-        const bgColor = isDarkColorScheme ? '#1e1e2e' : '#ffffff';
+        const bgColor = card;
 
         return (
             <Pressable onPress={() => resolvedRef.current?.focus()}>
@@ -152,7 +154,7 @@ const FloatingLabelInput = React.forwardRef<TextInput, FloatingLabelInputProps>(
                                 flex: 1,
                                 fontFamily: 'Inter',
                                 fontSize: 16,
-                                color: isDarkColorScheme ? '#ffffff' : '#111827',
+                                color: foreground,
                                 padding: 0,
                             },
                             style,

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -12,7 +12,7 @@ const SectionHeader = React.forwardRef<View, SectionHeaderProps>(
     ({ title, className }, ref) => {
         return (
             <View ref={ref} className={cn("flex-row items-center mb-3", className)}>
-                <View className="w-1 h-5 rounded-full bg-primary dark:bg-accent mr-2.5" />
+                <View className="w-1 h-5 rounded-full bg-primary mr-2.5" />
                 <Text className="text-lg font-semibold text-foreground">
                     {title}
                 </Text>

--- a/components/ui/userCard.tsx
+++ b/components/ui/userCard.tsx
@@ -11,7 +11,7 @@ export default function UserCard({ user }: { user: User }) {
                 <Image className="w-10 h-10 rounded-full" source={{ uri: user.image }} />
             ) : (
                 <View className="w-10 h-10 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
-                    <Text className="text-sm font-bold text-primary dark:text-accent">
+                    <Text className="text-sm font-bold text-primary">
                         {initials}
                     </Text>
                 </View>

--- a/global.css
+++ b/global.css
@@ -2,56 +2,71 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Fargene er de samme som nettsiden bruker, hentet fra
+ * `packages/ui/src/styles.css` i Photon-monorepoet. Der er de skrevet som
+ * oklch og hex; her må de stå som `H S% L%` fordi NativeWind slår dem opp med
+ * `hsl(var(--x))`. Hex-en i kommentaren er fasiten å sammenligne med.
+ *
+ * Endres en farge på nettsiden, må den endres her også — og i
+ * `lib/theme/colors.ts`, som holder de samme verdiene for det som ikke kan
+ * være en klasse (ikonfarger og andre props som tar en ren streng).
+ */
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 220 62% 41%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 62.8% 40.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.5rem;
+    --background: 0 0% 100%;              /* #ffffff */
+    --foreground: 0 0% 3.9%;              /* #0a0a0a */
+    --card: 0 0% 100%;                    /* #ffffff */
+    --card-foreground: 0 0% 3.9%;         /* #0a0a0a */
+    --popover: 0 0% 100%;                 /* #ffffff */
+    --popover-foreground: 0 0% 3.9%;      /* #0a0a0a */
+    --primary: 217.6 66.3% 32.5%;         /* #1c458a — TIHLDE-blå */
+    --primary-foreground: 0 0% 98%;       /* #fafafa */
+    --secondary: 0 0% 96.1%;              /* #f5f5f5 */
+    --secondary-foreground: 0 0% 9%;      /* #171717 */
+    --muted: 0 0% 96.1%;                  /* #f5f5f5 */
+    --muted-foreground: 0 0% 45.1%;       /* #737373 */
+    --accent: 0 0% 96.1%;                 /* #f5f5f5 */
+    --accent-foreground: 0 0% 9%;         /* #171717 */
+    --destructive: 357.1 100% 45.3%;      /* #e7000b */
+    --destructive-foreground: 0 0% 98%;   /* #fafafa */
+    --border: 0 0% 89.8%;                 /* #e5e5e5 */
+    --input: 0 0% 89.8%;                  /* #e5e5e5 */
+    --ring: 217.6 66.3% 32.5%;            /* #1c458a */
+    --radius: 0.625rem;
+
+    /* Varselfargene finnes ikke på nettsiden — den bruker egne komponenter
+       for dette — så de står som de var. */
     --alert-warning: 52.74 99% 76%;
     --alert-error: 359.72 100% 82%;
     --alert-success: 150.06 96% 45%;
     --alert-info: 210 40% 72%;
   }
 
+  /* Navy-paletten fra nettsidens mørke modus, bygget rundt #030b1a. */
   .dark:root {
-    --background: 246 17% 12%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 220 62% 41%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 230 100% 79%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    --background: 219.1 79.3% 5.7%;       /* #030b1a */
+    --foreground: 210 25% 96.9%;          /* #f5f7f9 */
+    --card: 219.5 78.6% 11%;              /* #061532 */
+    --card-foreground: 210 25% 96.9%;     /* #f5f7f9 */
+    --popover: 219.4 78% 16.1%;           /* #091f49 */
+    --popover-foreground: 210 25% 96.9%;  /* #f5f7f9 */
+    --primary: 219.1 78.8% 50%;           /* #1b61e4 */
+    --primary-foreground: 0 0% 100%;      /* #ffffff */
+    --secondary: 218.6 79.5% 24.9%;       /* #0d3172 */
+    --secondary-foreground: 210 25% 96.9%;/* #f5f7f9 */
+    --muted: 218.6 79.5% 24.9%;           /* #0d3172 */
+    --muted-foreground: 218.8 67% 62%;    /* #5d8bdf */
+    --accent: 218.6 79.5% 24.9%;          /* #0d3172 */
+    --accent-foreground: 210 25% 96.9%;   /* #f5f7f9 */
+    --destructive: 358.8 100% 69.6%;      /* #ff6467 */
+    --destructive-foreground: 210 25% 96.9%; /* #f5f7f9 */
+    --border: 218.6 79.5% 24.9%;          /* #0d3172 */
+    --input: 218.6 79.5% 24.9%;           /* #0d3172 */
+    --ring: 219.1 78.8% 50%;              /* #1b61e4 */
+
     --alert-warning: 44.37 100% 47%;
-    --alert-error: 356.95 96% 57.99999999999999%;
+    --alert-error: 356.95 96% 58%;
     --alert-success: 147.72 97% 20%;
     --alert-info: 215 76% 53%;
   }

--- a/lib/icons/TihldeLogo.tsx
+++ b/lib/icons/TihldeLogo.tsx
@@ -1,3 +1,4 @@
+import { themeColors } from "@/lib/theme/colors";
 import { cn } from 'lib/utils';
 import Svg, { ClipPath, Defs, G, Path } from 'react-native-svg';
 import { iconWithClassName } from './iconWithClassName';
@@ -10,10 +11,12 @@ export type TihldeLogoProps = {
 };
 
 const TihldeLogo = ({ size, className }: TihldeLogoProps) => {
-    let backgroundColor: string = '#2853a9';
-    if (useColorScheme().isDarkColorScheme) {
-        backgroundColor = '#FFFFFF';
-    }
+    // Logoen er TIHLDE-blå i lys modus og hvit i mørk, som på nettsiden:
+    // der er `--logo` satt til `--foreground` når temaet er mørkt.
+    const { isDarkColorScheme } = useColorScheme();
+    const backgroundColor = isDarkColorScheme
+        ? themeColors(true).foreground
+        : themeColors(false).primary;
 
     return (
         <Svg

--- a/lib/theme/colors.ts
+++ b/lib/theme/colors.ts
@@ -1,0 +1,66 @@
+/**
+ * Fargene fra nettsiden, som rene strenger.
+ *
+ * Samme verdier som `global.css`, bare i hex: en del props tar ikke en
+ * NativeWind-klasse — `color` på lucide-ikonene, `placeholderTextColor`,
+ * gradienter, SVG-fill — og før dette lå de som løse hex-literaler spredt over
+ * skjermene. De hadde drevet fra hverandre og fra nettsiden.
+ *
+ * Fasiten er `packages/ui/src/styles.css` i Photon-monorepoet. Endres en farge
+ * der, endres den her og i `global.css`.
+ */
+export type ThemeColors = {
+    background: string;
+    foreground: string;
+    card: string;
+    cardForeground: string;
+    popover: string;
+    primary: string;
+    primaryForeground: string;
+    secondary: string;
+    muted: string;
+    mutedForeground: string;
+    destructive: string;
+    border: string;
+    input: string;
+};
+
+const LIGHT: ThemeColors = {
+    background: "#ffffff",
+    foreground: "#0a0a0a",
+    card: "#ffffff",
+    cardForeground: "#0a0a0a",
+    popover: "#ffffff",
+    primary: "#1c458a",
+    primaryForeground: "#fafafa",
+    secondary: "#f5f5f5",
+    muted: "#f5f5f5",
+    mutedForeground: "#737373",
+    destructive: "#e7000b",
+    border: "#e5e5e5",
+    input: "#e5e5e5",
+};
+
+const DARK: ThemeColors = {
+    background: "#030b1a",
+    foreground: "#f5f7f9",
+    card: "#061532",
+    cardForeground: "#f5f7f9",
+    popover: "#091f49",
+    primary: "#1b61e4",
+    primaryForeground: "#ffffff",
+    secondary: "#0d3172",
+    muted: "#0d3172",
+    mutedForeground: "#5d8bdf",
+    destructive: "#ff6467",
+    border: "#0d3172",
+    input: "#0d3172",
+};
+
+/**
+ * Paletten for gjeldende modus. Tar flagget skjermene allerede har fra
+ * `useColorScheme()`, framfor å lese temaet en gang til.
+ */
+export function themeColors(isDarkColorScheme: boolean): ThemeColors {
+    return isDarkColorScheme ? DARK : LIGHT;
+}


### PR DESCRIPTION
Bygger på [#111](https://github.com/TIHLDE/Native/pull/111) — base er den grenen, så diffen her er bare fargene.

Appen hadde sin egen palett som lignet nettsidens uten å være den: primærblå `#2d5dab` mot nettsidens `#1c458a`, en helt annen mørk bakgrunn (`#001329` mot `#030b1a`), og en dryss gråtoner rett fra Tailwind. Fasiten er `packages/ui/src/styles.css` i Photon-monorepoet.

## Hva

**`global.css`** — samme verdier som nettsiden, regnet om fra oklch/hex til `H S% L%`, siden NativeWind slår dem opp med `hsl(var(--x))`. Hex-en står i kommentar på hver linje så de er til å sammenligne. `--radius` er også rettet (0.5 → 0.625rem).

**Mørk modus brukte feil token.** Mønsteret `text-primary dark:text-accent` gikk igjen 32 steder, fordi appens `accent` var en lys blåfarge. På nettsiden er `accent` en mørk navy, og `primary` er blåfargen i *begge* modus (`#1c458a` lys, `#1b61e4` mørk). Overstyringene er derfor fjernet, framfor å gjøre `accent` til noe annet enn den er.

**`lib/theme/colors.ts`** (ny) — ikonfarger, `placeholderTextColor`, gradienter og SVG-fill kan ikke være klasser, og lå som løse hex-literaler ute i skjermene. Nå ett sted, med samme verdier som `global.css`.

Varselfargene (`--alert-*`) står urørt: nettsiden har ingen tilsvarende tokens.

## Test

Målt pikslene i simulatoren, ikke bare sett på det:

| | målt | nettsiden |
|---|---|---|
| bakgrunn mørk | `#030b1a` | `#030b1a` |
| CTA mørk | `#1b61e4` | `#1b61e4` |
| bakgrunn lys | `#ffffff` | `#ffffff` |
| CTA lys | `#1c458a` | `#1c458a` |
| logo lys | `#1c458a` | `#1c458a` (`--logo`) |

`npx tsc --noEmit`: 23 feil før og etter — alle fra før.

Målingene er fra påloggingsskjermen, som er den eneste som er nåbar uten innlogging. Skjermene bak login bruker de samme tokenene, men er ikke verifisert enkeltvis ennå.

🤖 Generated with [Claude Code](https://claude.com/claude-code)