### PR TITLE
fix: Photon teller sider fra 0, ikke fra 1

### DIFF
--- a/actions/events/participants.ts
+++ b/actions/events/participants.ts
@@ -14,6 +14,9 @@ const PAGE_SIZE = 25;
  * Deltakerlista. Photon paginerer med side og sidestørrelse, og gir `nextPage`
  * som et tall — skjermene forventer `next` som en streng eller null, siden
  * Lepton ga en URL der.
+ *
+ * Sidetallene er nullbaserte: `page=0` er første side. Ba man om side 1 fikk
+ * man side to, og de første 25 deltakerne fantes ikke.
  */
 export async function eventParticipants(
     eventId: string,
@@ -21,7 +24,7 @@ export async function eventParticipants(
     search?: string
 ): Promise<{ results: Registration[]; next: string | null }> {
     const params = new URLSearchParams({
-        page: String(pageParam || 1),
+        page: String(pageParam),
         pageSize: String(PAGE_SIZE),
     });
     if (search) params.set("search", search);

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -534,7 +534,7 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
     } = useInfiniteQuery({
         queryKey: ["event", eventId, "participants", "public"],
         queryFn: async ({ pageParam }) => await publicEventParticipants(eventId, pageParam),
-        initialPageParam: 1,
+        initialPageParam: 0,
         getNextPageParam: (lastPage, allPages, lastPageParam) => {
             if (lastPage.next === null) return undefined;
             return lastPageParam + 1;

--- a/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
@@ -245,7 +245,7 @@ function ManualRegistration() {
     } = useInfiniteQuery({
         queryKey: ["event", id, "participants", debouncedSearch],
         queryFn: async ({ pageParam }) => await eventParticipants(id, pageParam, debouncedSearch || undefined),
-        initialPageParam: 1,
+        initialPageParam: 0,
         getNextPageParam: (lastPage, allPages, lastPageParam) => {
             if (lastPage.next === null) return undefined;
             return lastPageParam + 1;

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -80,13 +80,14 @@ export default function Arrangementer() {
     } = useInfiniteQuery({
         queryKey: ["events", debouncedSearch, filters.expired, filters.openForSignUp, filters.userFavorite],
         queryFn: fetchEvents,
-        initialPageParam: 1,
-        getNextPageParam: (lastPage, allPages, lastPageParam) => {
-            if (!lastPage.results || lastPage.results?.length === 0) {
-                return undefined;
-            }
-            return lastPageParam + 1;
-        },
+        // Photon teller sider fra 0. Med 1 her hoppet lista over de ti første
+        // arrangementene, så den startet midt i rekka i stedet for på det som
+        // skjer først.
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) =>
+            // `next` er Photons `nextPage`, som er null på siste side. Å telle
+            // opp selv ga en side til etter at lista var tom.
+            lastPage.next !== null ? Number(lastPage.next) : undefined,
     });
 
     const refreshControl = useRefresh(["events", debouncedSearch, filters.expired, filters.openForSignUp, filters.userFavorite]);


### PR DESCRIPTION
Appen ba om `page=1` som første side. Photon regner offset som `page * pageSize` (`getPageOffset` i `apps/api/src/middleware/pagination.ts`), så side 1 er *andre* side. Hver paginerte liste hoppet dermed stille over sine første treff.

På arrangementslista var det de ti første som forsvant — lista startet på Silent Disco 22. august i stedet for Facebook-vegg 11. august, som er det nettsiden viser. Det så ut som en sorteringsfeil, men rekkefølgen var riktig hele veien; starten manglet.

Deltakerlistene (både den offentlige og oppmøteregistreringen) mistet sine første 25 på samme måte.

Sideskiftet følger nå `nextPage` fra svaret framfor å telle opp selv. Den er `null` på siste side, så lista slutter å hente når den er tom, i stedet for å be om én side til og få et tomt svar.

`fetchGroupUsers` i `actions/fines/users.ts` er urørt: den henter hele medlemslista og paginerer selv, uten å sende `page` til Photon.

## Test

Mot prod-API-et, `expired=false&pageSize=10` — samme sidestørrelse som lista bruker:

```
page=0 → 11. aug Facebook-vegg / White Lie   ← samme som nettsiden
page=1 → 22. aug Silent Disco                ← det appen viste før
```

`npx tsc --noEmit`: 23 feil før og etter — alle fra før.

Ikke sett i appen ennå: listeskjermen krever innlogging, og sesjonen i simulatoren er utløpt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)