### PR TITLE
fix(auth): be om en JWT, og forny sesjonen bare én gang av gangen

### DIFF
--- a/lib/auth/photon.ts
+++ b/lib/auth/photon.ts
@@ -19,6 +19,19 @@ export const CLIENT_ID =
 
 export const SCOPES = ["openid", "profile", "email", "offline_access"];
 
+/**
+ * Hvem tokenet er ment for (RFC 8707 `resource`).
+ *
+ * Uten den gir Photon et opakt token — en ren streng uten krav i seg — og API-et
+ * avviser alt som krever innlogging med «Authentication required», fordi
+ * `requireAuth` bare godtar signerte JWT-er. Ber vi om denne mottakeren får vi
+ * en JWT i stedet, og resten av appen virker.
+ *
+ * Verdien må være en av utstederens godkjente mottakere; standarden er
+ * utstederen selv.
+ */
+export const RESOURCE = ISSUER;
+
 export const discovery: AuthSession.DiscoveryDocument = {
     authorizationEndpoint: `${ISSUER}/oauth2/authorize`,
     tokenEndpoint: `${ISSUER}/oauth2/token`,
@@ -65,6 +78,7 @@ export async function exchangeCode(
         client_id: CLIENT_ID,
         redirect_uri: redirectUri,
         code_verifier: codeVerifier,
+        resource: RESOURCE,
     });
 
     const res = await fetch(discovery.tokenEndpoint as string, {
@@ -86,13 +100,36 @@ export async function exchangeCode(
 }
 
 /**
+ * Fornyelsen som allerede er i gang, om noen.
+ *
+ * Photon roterer refresh-tokenet: hvert token kan brukes én gang, og brukes det
+ * samme to ganger tolkes det som tyveri — da slettes hele kjeden og brukeren er
+ * logget ut. En skjerm som henter tre ting samtidig fikk tre 401-er, som hver
+ * startet sin egen fornyelse med det samme tokenet. Første gikk igjennom, de to
+ * andre så ut som gjenbruk, og sesjonen røk.
+ *
+ * Derfor deler alle på det samme kallet: den som kommer først starter det,
+ * resten venter på svaret.
+ */
+let inFlightRefresh: Promise<string | null> | null = null;
+
+export function refreshSession(): Promise<string | null> {
+    if (!inFlightRefresh) {
+        inFlightRefresh = performRefresh().finally(() => {
+            inFlightRefresh = null;
+        });
+    }
+    return inFlightRefresh;
+}
+
+/**
  * Exchange the refresh token for a fresh access token.
  *
  * Returns null when the session cannot be renewed — a revoked or expired
  * refresh token — and clears the stored one so the app stops retrying with a
  * token the server has already rejected.
  */
-export async function refreshSession(): Promise<string | null> {
+async function performRefresh(): Promise<string | null> {
     const stored = await getSession();
     if (!stored?.refreshToken) return null;
 
@@ -100,6 +137,9 @@ export async function refreshSession(): Promise<string | null> {
         grant_type: "refresh_token",
         refresh_token: stored.refreshToken,
         client_id: CLIENT_ID,
+        // Må med her også: mottakeren avgjøres per utstedelse, så uten den
+        // faller man tilbake til et opakt token ved første fornyelse.
+        resource: RESOURCE,
     });
 
     const res = await fetch(discovery.tokenEndpoint as string, {


### PR DESCRIPTION
To feil funnet ved å teste innlogget på simulator mot prod. Begge endte med at innlogget innhold ikke virket i det hele tatt.

## 1. Appen fikk et opakt token, men API-et godtar bare JWT

Better Auth sin oauth-provider signerer access-tokenet **bare når kallet ber om en mottaker** (`resource`, RFC 8707) — ellers får man et opakt token, altså en ren streng uten krav i seg.

Photons `requireAuth` kjører `verifyJWTAccessToken`, som avviser alt som ikke er tre punktseparerte segmenter, og faller så tilbake på sesjonscookien. En OAuth-klient har ingen cookie, så svaret ble `401 Authentication required` på **alt** som krever innlogging: profil, påmeldingsstatus, bøter, oppmøteregistrering.

Vi ber nå om utstederen som mottaker, i både kodebyttet og fornyelsen. Da signeres tokenet, og `requireAuth` slipper det gjennom.

Verdien må ligge i utstederens `validAudiences`, som per nå er utstederen selv.

## 2. Samtidige fornyelser slettet sesjonen

Refresh-tokenet roteres, og gjenbruk av et brukt token tolkes som tyveri — da slettes hele kjeden.

Profilskjermen henter tre ting samtidig (`me()` gjør to kall, `myPermissions()` ett). Alle tre fikk 401, og hver startet sin egen fornyelse med det *samme* refresh-tokenet. Første gikk igjennom, de to andre så ut som gjenbruk, og serveren slettet alle tokens for klienten. Brukeren ble logget ut midt i økta.

Sett i prod-databasen: `auth_oauth_refresh_token` og `auth_oauth_access_token` gikk fra 2 og 11 rader til null i det profilskjermen ble åpnet.

Fornyelsen deles nå mellom alle som venter: den første starter kallet, resten venter på samme løfte.

## Test

`npx tsc --noEmit`: 23 feil før og etter — alle fra før.

Ikke verifisert i appen ennå: sesjonen ble slettet av feil 2 mens den ble funnet, så det trengs en ny innlogging for å se profilskjermen med data. Feil 1 er bekreftet i kildekoden på begge sider (`checkResource` i plugin-en, `verifyJWTAccessToken` i `apps/api/src/middleware/auth.ts`) og forklarer nøyaktig feilmeldingen skjermen viste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)