### PR TITLE
fix: vis riktig antall påmeldte, og «Leder» på norsk

### DIFF
--- a/actions/events/events.ts
+++ b/actions/events/events.ts
@@ -34,6 +34,38 @@ export async function fetchEvent(eventId: string): Promise<Event> {
     return toEvent((await response.json()) as PhotonEvent);
 }
 
+export type EventCounts = {
+    listCount: number;
+    /** Null når vi ikke har lov til å vite det. */
+    waitingListCount: number | null;
+};
+
+/**
+ * Antall påmeldte og på venteliste.
+ *
+ * Photon legger ikke tallene på selve arrangementet, slik Lepton gjorde — de
+ * kommer fra `totalCount` på påmeldingslista, som er det nettsiden bruker også.
+ * Én rad hentes bare for å få tellingen.
+ *
+ * Ventelista krever at man administrerer arrangementet, siden det er en
+ * statusfiltrering. For alle andre er tallet ukjent, ikke null.
+ */
+export async function fetchEventCounts(eventId: string): Promise<EventCounts> {
+    const path = `/event/${encodeURIComponent(eventId)}/registration?pageSize=1`;
+
+    const [registered, waitlisted] = await Promise.all([
+        apiJson<{ totalCount: number }>(path),
+        apiJson<{ totalCount: number }>(`${path}&status=waitlisted`).catch(
+            () => null,
+        ),
+    ]);
+
+    return {
+        listCount: registered.totalCount,
+        waitingListCount: waitlisted?.totalCount ?? null,
+    };
+}
+
 type PhotonJobPost = {
     id: string;
     title: string;

--- a/actions/events/participants.ts
+++ b/actions/events/participants.ts
@@ -14,6 +14,9 @@ const PAGE_SIZE = 25;
  * Deltakerlista. Photon paginerer med side og sidestørrelse, og gir `nextPage`
  * som et tall — skjermene forventer `next` som en streng eller null, siden
  * Lepton ga en URL der.
+ *
+ * Sidetallene er nullbaserte: `page=0` er første side. Ba man om side 1 fikk
+ * man side to, og de første 25 deltakerne fantes ikke.
  */
 export async function eventParticipants(
     eventId: string,
@@ -21,7 +24,7 @@ export async function eventParticipants(
     search?: string
 ): Promise<{ results: Registration[]; next: string | null }> {
     const params = new URLSearchParams({
-        page: String(pageParam || 1),
+        page: String(pageParam),
         pageSize: String(PAGE_SIZE),
     });
     if (search) params.set("search", search);

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -534,7 +534,7 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
     } = useInfiniteQuery({
         queryKey: ["event", eventId, "participants", "public"],
         queryFn: async ({ pageParam }) => await publicEventParticipants(eventId, pageParam),
-        initialPageParam: 1,
+        initialPageParam: 0,
         getNextPageParam: (lastPage, allPages, lastPageParam) => {
             if (lastPage.next === null) return undefined;
             return lastPageParam + 1;

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -5,7 +5,7 @@ import { View, Image, ActivityIndicator, Pressable } from "react-native";
 import MarkdownView from "@/components/ui/MarkdownView";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import PageWrapper from "@/components/ui/pagewrapper";
-import { fetchEvent } from "@/actions/events/events";
+import { fetchEvent, fetchEventCounts } from "@/actions/events/events";
 import { iAmRegisteredToEvent, registerToEvent, unregisterFromEvent } from "@/actions/events/registrations";
 import { Event, Registration } from "@/actions/types";
 import { useEffect, useRef, useState } from "react";
@@ -151,6 +151,13 @@ export default function ArrangementSide() {
     const { data: registration, isPending: registrationPending } = useQuery({
         queryKey: ["event", id, "registration"],
         queryFn: async () => iAmRegisteredToEvent(String(id)),
+    });
+
+    // Tallene ligger ikke på arrangementet i Photon; de telles på
+    // påmeldingslista. Egen spørring, så siden vises selv om den feiler.
+    const { data: counts } = useQuery({
+        queryKey: ["event", id, "counts"],
+        queryFn: async () => fetchEventCounts(String(id)),
     });
 
     const registrationMutation = useMutation({
@@ -330,13 +337,19 @@ export default function ArrangementSide() {
                                     <DetailRow
                                         icon={<Users size={18} color={mutedColor} />}
                                         label="Påmeldte"
-                                        value={`${event.data.list_count}/${event.data.limit === 0 ? "∞" : event.data.limit}`}
+                                        value={`${counts?.listCount ?? "–"}/${event.data.limit === 0 ? "∞" : event.data.limit}`}
                                     />
-                                    <DetailRow
-                                        icon={<Users size={18} color={mutedColor} />}
-                                        label="Venteliste"
-                                        value={String(event.data.waiting_list_count)}
-                                    />
+                                    {/* Ventelista er bare synlig for den som
+                                        administrerer arrangementet. Raden står
+                                        over når tallet er ukjent, framfor å
+                                        vise 0 og lyve. */}
+                                    {counts?.waitingListCount != null && (
+                                        <DetailRow
+                                            icon={<Users size={18} color={mutedColor} />}
+                                            label="Venteliste"
+                                            value={String(counts.waitingListCount)}
+                                        />
+                                    )}
                                     <DetailRow
                                         icon={<CalendarOff size={18} color={mutedColor} />}
                                         label="Avmeldingsfrist"
@@ -389,7 +402,7 @@ export default function ArrangementSide() {
                                 {...props}
                             />
                         )} >
-                        <EventParticipantsModal eventId={String(id)} totalCount={event.data.list_count} />
+                        <EventParticipantsModal eventId={String(id)} totalCount={String(counts?.listCount ?? 0)} />
                     </InteropBottomSheetModal>
 
                     <InteropBottomSheetModal ref={unregisterSheetRef}

--- a/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
@@ -245,7 +245,7 @@ function ManualRegistration() {
     } = useInfiniteQuery({
         queryKey: ["event", id, "participants", debouncedSearch],
         queryFn: async ({ pageParam }) => await eventParticipants(id, pageParam, debouncedSearch || undefined),
-        initialPageParam: 1,
+        initialPageParam: 0,
         getNextPageParam: (lastPage, allPages, lastPageParam) => {
             if (lastPage.next === null) return undefined;
             return lastPageParam + 1;

--- a/app/(app)/(modals)/boter/index.tsx
+++ b/app/(app)/(modals)/boter/index.tsx
@@ -72,9 +72,9 @@ export default function MembershipSelection() {
                                 {membership.group.name}
                             </Text>
                             <Text className="text-sm text-muted-foreground mt-0.5">
-                                {membership.membership_type === "MEMBER"
-                                    ? "Medlem"
-                                    : membership.membership_type}
+                                {membership.membership_type === "LEADER"
+                                    ? "Leder"
+                                    : "Medlem"}
                             </Text>
                         </View>
                         <ChevronRight size={20} color={mutedColor} />

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -80,13 +80,14 @@ export default function Arrangementer() {
     } = useInfiniteQuery({
         queryKey: ["events", debouncedSearch, filters.expired, filters.openForSignUp, filters.userFavorite],
         queryFn: fetchEvents,
-        initialPageParam: 1,
-        getNextPageParam: (lastPage, allPages, lastPageParam) => {
-            if (!lastPage.results || lastPage.results?.length === 0) {
-                return undefined;
-            }
-            return lastPageParam + 1;
-        },
+        // Photon teller sider fra 0. Med 1 her hoppet lista over de ti første
+        // arrangementene, så den startet midt i rekka i stedet for på det som
+        // skjer først.
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) =>
+            // `next` er Photons `nextPage`, som er null på siste side. Å telle
+            // opp selv ga en side til etter at lista var tom.
+            lastPage.next !== null ? Number(lastPage.next) : undefined,
     });
 
     const refreshControl = useRefresh(["events", debouncedSearch, filters.expired, filters.openForSignUp, filters.userFavorite]);

--- a/lib/auth/photon.ts
+++ b/lib/auth/photon.ts
@@ -19,6 +19,19 @@ export const CLIENT_ID =
 
 export const SCOPES = ["openid", "profile", "email", "offline_access"];
 
+/**
+ * Hvem tokenet er ment for (RFC 8707 `resource`).
+ *
+ * Uten den gir Photon et opakt token — en ren streng uten krav i seg — og API-et
+ * avviser alt som krever innlogging med «Authentication required», fordi
+ * `requireAuth` bare godtar signerte JWT-er. Ber vi om denne mottakeren får vi
+ * en JWT i stedet, og resten av appen virker.
+ *
+ * Verdien må være en av utstederens godkjente mottakere; standarden er
+ * utstederen selv.
+ */
+export const RESOURCE = ISSUER;
+
 export const discovery: AuthSession.DiscoveryDocument = {
     authorizationEndpoint: `${ISSUER}/oauth2/authorize`,
     tokenEndpoint: `${ISSUER}/oauth2/token`,
@@ -65,6 +78,7 @@ export async function exchangeCode(
         client_id: CLIENT_ID,
         redirect_uri: redirectUri,
         code_verifier: codeVerifier,
+        resource: RESOURCE,
     });
 
     const res = await fetch(discovery.tokenEndpoint as string, {
@@ -86,13 +100,36 @@ export async function exchangeCode(
 }
 
 /**
+ * Fornyelsen som allerede er i gang, om noen.
+ *
+ * Photon roterer refresh-tokenet: hvert token kan brukes én gang, og brukes det
+ * samme to ganger tolkes det som tyveri — da slettes hele kjeden og brukeren er
+ * logget ut. En skjerm som henter tre ting samtidig fikk tre 401-er, som hver
+ * startet sin egen fornyelse med det samme tokenet. Første gikk igjennom, de to
+ * andre så ut som gjenbruk, og sesjonen røk.
+ *
+ * Derfor deler alle på det samme kallet: den som kommer først starter det,
+ * resten venter på svaret.
+ */
+let inFlightRefresh: Promise<string | null> | null = null;
+
+export function refreshSession(): Promise<string | null> {
+    if (!inFlightRefresh) {
+        inFlightRefresh = performRefresh().finally(() => {
+            inFlightRefresh = null;
+        });
+    }
+    return inFlightRefresh;
+}
+
+/**
  * Exchange the refresh token for a fresh access token.
  *
  * Returns null when the session cannot be renewed — a revoked or expired
  * refresh token — and clears the stored one so the app stops retrying with a
  * token the server has already rejected.
  */
-export async function refreshSession(): Promise<string | null> {
+async function performRefresh(): Promise<string | null> {
     const stored = await getSession();
     if (!stored?.refreshToken) return null;
 
@@ -100,6 +137,9 @@ export async function refreshSession(): Promise<string | null> {
         grant_type: "refresh_token",
         refresh_token: stored.refreshToken,
         client_id: CLIENT_ID,
+        // Må med her også: mottakeren avgjøres per utstedelse, så uten den
+        // faller man tilbake til et opakt token ved første fornyelse.
+        resource: RESOURCE,
     });
 
     const res = await fetch(discovery.tokenEndpoint as string, {


### PR DESCRIPTION
Bygger på [#114](https://github.com/TIHLDE/Native/pull/114) — base er den grenen, så diffen her er bare disse to tingene. #114 må inn først.

## Påmeldingstallet var alltid 0

Arrangementssiden viste «Påmeldte 0/∞» uansett. Photon legger ikke tallet på selve arrangementet slik Lepton gjorde, og oversettelsen i `actions/photon.ts` satte det derfor til `0`.

Tallet hentes nå fra `totalCount` på påmeldingslista (`/event/:id/registration?pageSize=1`) — samme kilde nettsiden bruker (`registrations?.totalCount` i `arrangementer.$slug.tsx`). Én rad hentes bare for å få tellingen.

Ventelista krever at man administrerer arrangementet, siden det er en statusfiltrering (`status=waitlisted`). For alle andre er tallet ukjent, så raden står over framfor å vise 0 og lyve.

## «LEADER» i bøtenes gruppevelger

Rollen ble vist rått fra API-et for ledere, mens medlemmer fikk «Medlem». Nå «Leder».

## Test

Verifisert på simulator mot prod: «Facebook-vegg / White Lie» viser nå **2/∞**, som stemmer med databasen (2 rader med status `registered`). Før viste den 0/∞.

`npx tsc --noEmit`: 23 feil før og etter — alle fra før.

🤖 Generated with [Claude Code](https://claude.com/claude-code)