### PR TITLE
fix: vis riktig antall påmeldte, og «Leder» på norsk

### DIFF
--- a/actions/events/events.ts
+++ b/actions/events/events.ts
@@ -34,6 +34,38 @@ export async function fetchEvent(eventId: string): Promise<Event> {
     return toEvent((await response.json()) as PhotonEvent);
 }
 
+export type EventCounts = {
+    listCount: number;
+    /** Null når vi ikke har lov til å vite det. */
+    waitingListCount: number | null;
+};
+
+/**
+ * Antall påmeldte og på venteliste.
+ *
+ * Photon legger ikke tallene på selve arrangementet, slik Lepton gjorde — de
+ * kommer fra `totalCount` på påmeldingslista, som er det nettsiden bruker også.
+ * Én rad hentes bare for å få tellingen.
+ *
+ * Ventelista krever at man administrerer arrangementet, siden det er en
+ * statusfiltrering. For alle andre er tallet ukjent, ikke null.
+ */
+export async function fetchEventCounts(eventId: string): Promise<EventCounts> {
+    const path = `/event/${encodeURIComponent(eventId)}/registration?pageSize=1`;
+
+    const [registered, waitlisted] = await Promise.all([
+        apiJson<{ totalCount: number }>(path),
+        apiJson<{ totalCount: number }>(`${path}&status=waitlisted`).catch(
+            () => null,
+        ),
+    ]);
+
+    return {
+        listCount: registered.totalCount,
+        waitingListCount: waitlisted?.totalCount ?? null,
+    };
+}
+
 type PhotonJobPost = {
     id: string;
     title: string;

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -5,7 +5,7 @@ import { View, Image, ActivityIndicator, Pressable } from "react-native";
 import MarkdownView from "@/components/ui/MarkdownView";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import PageWrapper from "@/components/ui/pagewrapper";
-import { fetchEvent } from "@/actions/events/events";
+import { fetchEvent, fetchEventCounts } from "@/actions/events/events";
 import { iAmRegisteredToEvent, registerToEvent, unregisterFromEvent } from "@/actions/events/registrations";
 import { Event, Registration } from "@/actions/types";
 import { useEffect, useRef, useState } from "react";
@@ -151,6 +151,13 @@ export default function ArrangementSide() {
     const { data: registration, isPending: registrationPending } = useQuery({
         queryKey: ["event", id, "registration"],
         queryFn: async () => iAmRegisteredToEvent(String(id)),
+    });
+
+    // Tallene ligger ikke på arrangementet i Photon; de telles på
+    // påmeldingslista. Egen spørring, så siden vises selv om den feiler.
+    const { data: counts } = useQuery({
+        queryKey: ["event", id, "counts"],
+        queryFn: async () => fetchEventCounts(String(id)),
     });
 
     const registrationMutation = useMutation({
@@ -330,13 +337,19 @@ export default function ArrangementSide() {
                                     <DetailRow
                                         icon={<Users size={18} color={mutedColor} />}
                                         label="Påmeldte"
-                                        value={`${event.data.list_count}/${event.data.limit === 0 ? "∞" : event.data.limit}`}
+                                        value={`${counts?.listCount ?? "–"}/${event.data.limit === 0 ? "∞" : event.data.limit}`}
                                     />
-                                    <DetailRow
-                                        icon={<Users size={18} color={mutedColor} />}
-                                        label="Venteliste"
-                                        value={String(event.data.waiting_list_count)}
-                                    />
+                                    {/* Ventelista er bare synlig for den som
+                                        administrerer arrangementet. Raden står
+                                        over når tallet er ukjent, framfor å
+                                        vise 0 og lyve. */}
+                                    {counts?.waitingListCount != null && (
+                                        <DetailRow
+                                            icon={<Users size={18} color={mutedColor} />}
+                                            label="Venteliste"
+                                            value={String(counts.waitingListCount)}
+                                        />
+                                    )}
                                     <DetailRow
                                         icon={<CalendarOff size={18} color={mutedColor} />}
                                         label="Avmeldingsfrist"
@@ -389,7 +402,7 @@ export default function ArrangementSide() {
                                 {...props}
                             />
                         )} >
-                        <EventParticipantsModal eventId={String(id)} totalCount={event.data.list_count} />
+                        <EventParticipantsModal eventId={String(id)} totalCount={String(counts?.listCount ?? 0)} />
                     </InteropBottomSheetModal>
 
                     <InteropBottomSheetModal ref={unregisterSheetRef}

--- a/app/(app)/(modals)/boter/index.tsx
+++ b/app/(app)/(modals)/boter/index.tsx
@@ -72,9 +72,9 @@ export default function MembershipSelection() {
                                 {membership.group.name}
                             </Text>
                             <Text className="text-sm text-muted-foreground mt-0.5">
-                                {membership.membership_type === "MEMBER"
-                                    ? "Medlem"
-                                    : membership.membership_type}
+                                {membership.membership_type === "LEADER"
+                                    ? "Leder"
+                                    : "Medlem"}
                             </Text>
                         </View>
                         <ChevronRight size={20} color={mutedColor} />


### PR DESCRIPTION
Samme endring som [#115](https://github.com/TIHLDE/Native/pull/115), som aldri nådde `main`: den hadde `fix/jwt-access-token` som base, og den grenen var allerede merget. GitHub markerte #115 som merget, men commiten ble liggende igjen i grenen. Denne er cherry-picket rett på `main`.

## Påmeldingstallet var alltid 0

Arrangementssiden viste «Påmeldte 0/∞» uansett. Photon legger ikke tallet på selve arrangementet slik Lepton gjorde, og oversettelsen i `actions/photon.ts` satte det derfor til `0`.

Tallet hentes nå fra `totalCount` på påmeldingslista (`/event/:id/registration?pageSize=1`) — samme kilde nettsiden bruker. Én rad hentes bare for å få tellingen.

Ventelista krever at man administrerer arrangementet, siden det er en statusfiltrering (`status=waitlisted`). For alle andre er tallet ukjent, så raden står over framfor å vise 0 og lyve.

## «LEADER» i bøtenes gruppevelger

Rollen ble vist rått fra API-et for ledere, mens medlemmer fikk «Medlem». Nå «Leder».

## Test

Verifisert på simulator mot prod: «Facebook-vegg / White Lie» viser **2/∞**, som stemmer med databasen. Før viste den 0/∞.

`npx tsc --noEmit`: 23 feil før og etter — alle fra før.

🤖 Generated with [Claude Code](https://claude.com/claude-code)