### PR TITLE
fix: skjul avmeldingsfristen når arrangementet ikke har en

### DIFF
--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -224,6 +224,16 @@ export default function ArrangementSide() {
         );
     }
 
+    /**
+     * Photon lar tidspunktene stå tomme der Lepton alltid hadde dem. En tom
+     * streng blir en ugyldig dato, som både vises som «Invalid Date» og gjør
+     * enhver sammenligning usann uten å si fra.
+     */
+    const isValidDate = (dateStr: string) =>
+        Boolean(dateStr) && !Number.isNaN(new Date(dateStr).getTime());
+
+    const hasSignOffDeadline = isValidDate(event.data.sign_off_deadline);
+
     const formatDate = (dateStr: string) =>
         new Date(dateStr).toLocaleDateString("no-NO", {
             year: "numeric",
@@ -350,12 +360,17 @@ export default function ArrangementSide() {
                                             value={String(counts.waitingListCount)}
                                         />
                                     )}
-                                    <DetailRow
-                                        icon={<CalendarOff size={18} color={mutedColor} />}
-                                        label="Avmeldingsfrist"
-                                        value={`${formatDate(event.data.sign_off_deadline)} kl. ${formatTime(event.data.sign_off_deadline)}`}
-                                        isLast
-                                    />
+                                    {/* Photon lar avmeldingsfristen stå tom;
+                                        Lepton hadde den alltid. Uten sjekken
+                                        her ble raden til «Invalid Date». */}
+                                    {hasSignOffDeadline && (
+                                        <DetailRow
+                                            icon={<CalendarOff size={18} color={mutedColor} />}
+                                            label="Avmeldingsfrist"
+                                            value={`${formatDate(event.data.sign_off_deadline)} kl. ${formatTime(event.data.sign_off_deadline)}`}
+                                            isLast
+                                        />
+                                    )}
                                 </View>
 
                                 <RegistrationButton
@@ -418,7 +433,11 @@ export default function ArrangementSide() {
                         )} >
                         <UnregisterDrawer
                             eventId={String(id)}
-                            isPastDeadline={isBefore(new Date(event.data.sign_off_deadline), new Date())}
+                            // Uten frist er det aldri for sent å melde seg av.
+                            isPastDeadline={
+                                hasSignOffDeadline &&
+                                isBefore(new Date(event.data.sign_off_deadline), new Date())
+                            }
                             sheetRef={unregisterSheetRef}
                         />
                     </InteropBottomSheetModal>


### PR DESCRIPTION
Arrangementssiden viste «Avmeldingsfrist: **Invalid Date** kl. Invalid Date».

Photon lar `cancellationDeadline` stå tom der Lepton alltid hadde den. Oversettelsen i `actions/photon.ts` gjør `null` til `""`, og `new Date("")` er en ugyldig dato. Det gjelder blant annet alle fadderukas arrangementer — «Facebook-vegg / White Lie» har verken `cancellationDeadline` eller `registrationStart`.

Raden står nå over når fristen mangler.

Avmeldingsknappen sammenlignet også mot den ugyldige datoen. `isBefore(Invalid Date, now)` er `false`, så utfallet var riktig — det er aldri for sent å melde seg av når det ikke finnes en frist — men ved uhell, ikke fordi det stod der. Nå står det der.

## Test

Verifisert på simulator mot prod, med `main` sjekket ut: raden er borte på «Facebook-vegg / White Lie», og resten av kortet (Påmeldte 2/∞, Venteliste 0) står som før.

`npx tsc --noEmit`: 23 feil før og etter — alle fra før.

🤖 Generated with [Claude Code](https://claude.com/claude-code)