### PR TITLE
Utleggsfane: send inn utlegg med kvittering fra kameraet

### DIFF
--- a/actions/applications/applications.ts
+++ b/actions/applications/applications.ts
@@ -1,0 +1,57 @@
+import { apiJson } from "@/lib/api/client";
+import type {
+    ApplicationDetail,
+    ApplicationOptions,
+    ApplicationSummary,
+    CreateApplicationResponse,
+    CreateExpensePayload,
+} from "@/actions/types";
+
+/** Gruppene, budsjettypene og kopimottakerne skjemaet kan velge mellom. */
+export async function applicationOptions(): Promise<ApplicationOptions> {
+    return apiJson<ApplicationOptions>("/applications/options");
+}
+
+const PAGE_SIZE = 25;
+
+/**
+ * Mine utlegg, nyeste først.
+ *
+ * Photon svarer med en naken array uten totalantall, så neste side utledes av
+ * at siden kom full: en kortere side er den siste. `/mine` dekker alle
+ * søknadstyper, og `type=expense` holder listen til det fanen handler om.
+ */
+export async function myExpenses(
+    offset: number,
+): Promise<{ results: ApplicationSummary[]; next: number | null }> {
+    const results = await apiJson<ApplicationSummary[]>(
+        `/applications/mine?type=expense&limit=${PAGE_SIZE}&offset=${offset}`,
+    );
+
+    return {
+        results,
+        next: results.length === PAGE_SIZE ? offset + PAGE_SIZE : null,
+    };
+}
+
+export async function application(id: string): Promise<ApplicationDetail> {
+    return apiJson<ApplicationDetail>(`/applications/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Sender inn et utlegg. Kvitteringene må være lastet opp på forhånd, og
+ * `attachmentKeys` inneholder nøklene `uploadReceipt` ga tilbake.
+ *
+ * Photon ruller hele søknaden tilbake om én nøkkel ikke går gjennom, så et
+ * avslag her betyr at ingenting ble lagret.
+ */
+export async function createExpense(
+    payload: CreateExpensePayload,
+): Promise<CreateApplicationResponse> {
+    return apiJson<CreateApplicationResponse>("/applications/expense", {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
+}
+
+export { PAGE_SIZE };

--- a/actions/applications/upload.ts
+++ b/actions/applications/upload.ts
@@ -1,0 +1,76 @@
+import { API_URL } from "@/actions/constant";
+import { getValidAccessToken } from "@/lib/auth/photon";
+import { UnauthorizedError } from "@/lib/api/client";
+
+type UploadedAsset = {
+    key: string;
+    originalFilename: string;
+    contentType: string | null;
+    size: number;
+    status: "staged" | "ready";
+};
+
+/** Photon avviser alt annet, så filen stoppes her framfor å bli lastet opp forgjeves. */
+const ALLOWED_EXTENSIONS: Record<string, string> = {
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    png: "image/png",
+    gif: "image/gif",
+    webp: "image/webp",
+    pdf: "application/pdf",
+};
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+
+/**
+ * Laster opp en kvittering og returnerer asset-nøkkelen.
+ *
+ * Til forskjell fra `uploadImage` i bøtene lastes denne opp som `private`:
+ * `GET /assets/:key` er åpen for alle, og en kvittering med kontoutskrift eller
+ * kjøpshistorikk skal ikke kunne hentes av hvem som helst med nøkkelen.
+ *
+ * Nøkkelen returneres rå, ikke som URL — `attachmentKeys` på utlegget vil ha
+ * nettopp nøkkelen, og Photon avviser søknaden om den får noe annet.
+ *
+ * Går utenom apiFetch fordi den setter Content-Type til application/json; en
+ * multipart-body må ha grensen sin satt av runtime.
+ */
+export async function uploadReceipt(uri: string): Promise<string> {
+    const token = await getValidAccessToken();
+    if (!token) throw new UnauthorizedError();
+
+    const filename = uri.split("/").pop() ?? "kvittering.jpg";
+    const extension = /\.(\w+)$/.exec(filename)?.[1]?.toLowerCase();
+    const type = extension ? ALLOWED_EXTENSIONS[extension] : undefined;
+
+    if (!type) {
+        throw new Error(
+            "Filtypen støttes ikke. Bruk bilde (JPG, PNG, GIF, WEBP) eller PDF.",
+        );
+    }
+
+    const formData = new FormData();
+    formData.append("file", { uri, name: filename, type } as any);
+    // Uten dette blir kvitteringen offentlig — Photons standard er "public".
+    formData.append("visibility", "private");
+
+    const response = await fetch(`${API_URL}/assets`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+    });
+
+    if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+            | { message?: string }
+            | null;
+        throw new Error(
+            body?.message ?? `Opplasting av kvittering feilet (${response.status})`,
+        );
+    }
+
+    const asset = (await response.json()) as UploadedAsset;
+    return asset.key;
+}
+
+export { MAX_FILE_SIZE };

--- a/actions/types/application.ts
+++ b/actions/types/application.ts
@@ -1,0 +1,95 @@
+/**
+ * Søknader i Photon. Appen bruker bare utleggstypen, men status- og
+ * typefeltene er delt av alle søknadene og beholder derfor hele verdisettet.
+ */
+
+export type ApplicationType =
+    | "expense"
+    | "support"
+    | "sports_support"
+    | "hs_case"
+    | "company_contact";
+
+export type ApplicationStatus = "new" | "in_progress" | "approved" | "rejected";
+
+export type BudgetType =
+    | "social_budget"
+    | "group_budget"
+    | "approved_hs_application"
+    | "approved_idkom_application";
+
+/** Valglistene skjemaet fylles fra. Labels kommer ferdig oversatt fra Photon. */
+export type ApplicationOptions = {
+    groups: { slug: string; name: string }[];
+    ccOptions: { slug: string; name: string; email: string }[];
+    budgetTypes: { value: BudgetType; label: string }[];
+    caseTypes: { value: string; label: string }[];
+};
+
+/** Raden i listevisningen. Selve utleggsdetaljene ligger bare på detaljruta. */
+export type ApplicationSummary = {
+    id: string;
+    type: ApplicationType;
+    typeLabel: string;
+    status: ApplicationStatus;
+    statusLabel: string;
+    title: string;
+    contactName: string;
+    contactEmail: string;
+    submittedById: string | null;
+    submittedByName: string | null;
+    amountNok: number | null;
+    groupName: string | null;
+    hasPdf: boolean;
+    handledByName: string | null;
+    handledAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+};
+
+export type ApplicationAttachment = {
+    id: string;
+    assetKey: string;
+    kind: "receipt" | "budget" | "attachment";
+    sortOrder: number;
+};
+
+export type ExpenseDetail = {
+    ccEmail: string | null;
+    amountNok: number;
+    expenseDate: string;
+    budgetType: BudgetType;
+    budgetTypeLabel: string;
+    description: string;
+    accountNumber: string;
+    group: { slug: string; name: string };
+};
+
+export type ApplicationDetail = ApplicationSummary & {
+    signature: string;
+    attachments: ApplicationAttachment[];
+    expense: ExpenseDetail | null;
+};
+
+/** Kroppen `POST /applications/expense` tar imot. */
+export type CreateExpensePayload = {
+    contactName: string;
+    contactEmail: string;
+    ccEmail?: string;
+    amountNok: number;
+    expenseDate: string;
+    groupSlug: string;
+    budgetType: BudgetType;
+    description: string;
+    accountNumber: string;
+    attachmentKeys: string[];
+};
+
+/**
+ * `pdfGenerated: false` betyr at utlegget er lagret, men at PDF-en ikke ble
+ * laget — søknaden er altså sendt inn, og skal ikke framstå som mislykket.
+ */
+export type CreateApplicationResponse = {
+    id: string;
+    pdfGenerated: boolean;
+};

--- a/actions/types/index.ts
+++ b/actions/types/index.ts
@@ -7,3 +7,4 @@ export * from "./event";
 export * from "./registration";
 export * from "./payment";
 export * from "./fine";
+export * from "./application";

--- a/app/(app)/(tabs)/_layout.tsx
+++ b/app/(app)/(tabs)/_layout.tsx
@@ -15,6 +15,7 @@ export default function TabsLayout() {
     const { isDarkColorScheme } = useColorScheme();
     const insets = useSafeAreaInsets();
 
+    const isUtlegg = pathname.includes("/utlegg");
     const isKarriere = pathname.includes("/karriere");
     const isArrangementer = pathname.includes("/arrangementer");
     const isProfil = pathname.includes("/profil");
@@ -29,6 +30,29 @@ export default function TabsLayout() {
                     style={StyleSheet.absoluteFill}
                 />
                 <View style={styles.topBorder} className="bg-border/30 dark:bg-white/8" />
+
+                {/* Utlegg tab */}
+                <TabTrigger name="utlegg" href="/utlegg" reset="never" style={styles.tabItem}>
+                    <View className={`rounded-2xl py-1.5 items-center w-20 ${
+                        isUtlegg ? "bg-primary/15" : ""
+                    }`}>
+                        <Icon
+                            icon="ReceiptText"
+                            className={`self-center stroke-2 ${
+                                isUtlegg
+                                    ? "color-primary"
+                                    : "color-gray-400 dark:color-gray-500"
+                            }`}
+                        />
+                        <Text className={`text-[10px] mt-0.5 font-semibold ${
+                            isUtlegg
+                                ? "color-primary"
+                                : "color-gray-400 dark:color-gray-500"
+                        }`}>
+                            Utlegg
+                        </Text>
+                    </View>
+                </TabTrigger>
 
                 {/* Karriere tab */}
                 <TabTrigger name="karriere" href="/karriere" reset="never" style={styles.tabItem}>
@@ -53,6 +77,18 @@ export default function TabsLayout() {
                     </View>
                 </TabTrigger>
 
+                {/* QR center button */}
+                <View style={styles.qrContainer}>
+                    <TouchableWithoutFeedback onPress={() => router.push('/(modals)/qrmodal')}>
+                        <View
+                            className="bg-primary items-center justify-center"
+                            style={styles.qrButton}
+                        >
+                            <QrCode className="color-white dark:color-background" size={26} />
+                        </View>
+                    </TouchableWithoutFeedback>
+                </View>
+
                 {/* Arrangementer tab */}
                 <TabTrigger name="arrangementer" href="/arrangementer" reset="never" style={styles.tabItem}>
                     <View className={`rounded-2xl py-1.5 items-center w-20 ${
@@ -75,21 +111,6 @@ export default function TabsLayout() {
                         </Text>
                     </View>
                 </TabTrigger>
-
-                {/* QR center button */}
-                <View style={styles.qrContainer}>
-                    <TouchableWithoutFeedback onPress={() => router.push('/(modals)/qrmodal')}>
-                        <View
-                            className="bg-primary items-center justify-center"
-                            style={styles.qrButton}
-                        >
-                            <QrCode className="color-white dark:color-background" size={26} />
-                        </View>
-                    </TouchableWithoutFeedback>
-                </View>
-
-                {/* Holder QR-knappen midtstilt: to plasser på hver side. */}
-                <View style={styles.tabItem} />
 
                 {/* Profil tab */}
                 <TabTrigger name="profil" href="/profil" reset="never" style={styles.tabItem}>

--- a/app/(app)/(tabs)/utlegg/_layout.tsx
+++ b/app/(app)/(tabs)/utlegg/_layout.tsx
@@ -1,0 +1,31 @@
+import { Stack } from "expo-router";
+import FinesHeaderButton from "@/components/boter/FinesFAB";
+
+export default function UtleggLayout() {
+    return (
+        <Stack
+            screenOptions={{
+                headerBackTitle: "Tilbake",
+            }}
+        >
+            <Stack.Screen
+                name="index"
+                options={{
+                    headerShown: true,
+                    title: "Utlegg",
+                    headerBackTitle: "Tilbake",
+                    headerTitleAlign: "center",
+                    headerRight: () => <FinesHeaderButton />,
+                }}
+            />
+            <Stack.Screen
+                name="nytt"
+                options={{
+                    headerShown: true,
+                    title: "Nytt utlegg",
+                    headerTitleAlign: "center",
+                }}
+            />
+        </Stack>
+    );
+}

--- a/app/(app)/(tabs)/utlegg/index.tsx
+++ b/app/(app)/(tabs)/utlegg/index.tsx
@@ -1,0 +1,100 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { router } from "expo-router";
+import { ActivityIndicator, FlatList, Pressable, View } from "react-native";
+import { Plus, ReceiptText } from "lucide-react-native";
+import { myExpenses } from "@/actions/applications/applications";
+import ExpenseCard, {
+    ExpenseCardSkeleton,
+} from "@/components/utlegg/expenseCard";
+import PageWrapper from "@/components/ui/pagewrapper";
+import { Text } from "@/components/ui/text";
+import useRefresh from "@/lib/useRefresh";
+import { useColorScheme } from "@/lib/useColorScheme";
+import { themeColors } from "@/lib/theme/colors";
+
+export default function Utlegg() {
+    const { isDarkColorScheme } = useColorScheme();
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
+
+    const {
+        data,
+        error,
+        fetchNextPage,
+        hasNextPage,
+        isPending,
+        isError,
+        isFetchingNextPage,
+    } = useInfiniteQuery({
+        queryKey: ["applications", "mine", "expense"],
+        queryFn: ({ pageParam }) => myExpenses(pageParam),
+        initialPageParam: 0,
+        // `next` er null på siste side; å telle opp selv ville gitt en tom
+        // side til etter at lista var slutt.
+        getNextPageParam: (lastPage) => lastPage.next ?? undefined,
+    });
+
+    const refreshControl = useRefresh(["applications", "mine", "expense"]);
+
+    const expenses = data?.pages.flatMap((page) => page.results) ?? [];
+
+    return (
+        <PageWrapper className="flex-1 bg-background">
+            <FlatList
+                data={expenses}
+                keyExtractor={(item) => item.id}
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 24, paddingBottom: 100 }}
+                refreshControl={refreshControl}
+                ListHeaderComponent={
+                    <Pressable
+                        onPress={() => router.push("/utlegg/nytt")}
+                        className="flex-row items-center justify-center h-14 rounded-2xl bg-primary my-4 active:opacity-80"
+                    >
+                        <Plus size={20} color="#ffffff" />
+                        <Text
+                            className="text-base font-semibold text-white ml-2"
+                            style={{ fontFamily: "Inter" }}
+                        >
+                            Nytt utlegg
+                        </Text>
+                    </Pressable>
+                }
+                ListEmptyComponent={
+                    isPending ? (
+                        <View>
+                            <ExpenseCardSkeleton />
+                            <ExpenseCardSkeleton />
+                            <ExpenseCardSkeleton />
+                        </View>
+                    ) : isError ? (
+                        <View className="items-center py-12">
+                            <Text className="text-destructive text-center">
+                                {error.message}
+                            </Text>
+                        </View>
+                    ) : (
+                        <View className="items-center py-16">
+                            <ReceiptText size={40} color={mutedColor} />
+                            <Text className="text-base text-muted-foreground text-center mt-4">
+                                Du har ikke sendt inn noen utlegg
+                            </Text>
+                            <Text className="text-sm text-muted-foreground text-center mt-1">
+                                Ta bilde av kvitteringen og send den inn med en gang.
+                            </Text>
+                        </View>
+                    )
+                }
+                renderItem={({ item }) => <ExpenseCard expense={item} />}
+                onEndReached={() => {
+                    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+                }}
+                onEndReachedThreshold={0.5}
+                ListFooterComponent={
+                    isFetchingNextPage ? (
+                        <ActivityIndicator className="my-4" color={mutedColor} />
+                    ) : null
+                }
+            />
+        </PageWrapper>
+    );
+}

--- a/app/(app)/(tabs)/utlegg/nytt.tsx
+++ b/app/(app)/(tabs)/utlegg/nytt.tsx
@@ -1,0 +1,591 @@
+import { useEffect, useState } from "react";
+import {
+    ActivityIndicator,
+    Image,
+    KeyboardAvoidingView,
+    Platform,
+    Pressable,
+    ScrollView,
+    TextInput,
+    View,
+} from "react-native";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import * as ImagePicker from "expo-image-picker";
+import Toast from "react-native-toast-message";
+import {
+    Camera,
+    Check,
+    CheckCircle,
+    ChevronDown,
+    FileText,
+    ImagePlus,
+    TriangleAlert,
+    X,
+} from "lucide-react-native";
+import me from "@/actions/users/me";
+import {
+    applicationOptions,
+    createExpense,
+} from "@/actions/applications/applications";
+import { uploadReceipt } from "@/actions/applications/upload";
+import PageWrapper from "@/components/ui/pagewrapper";
+import { Text } from "@/components/ui/text";
+import { SectionHeader } from "@/components/ui/section-header";
+import { useColorScheme } from "@/lib/useColorScheme";
+import { themeColors } from "@/lib/theme/colors";
+import type { BudgetType } from "@/actions/types";
+
+/** En valgt kvittering. `key` settes først når fila er lastet opp. */
+type Receipt = {
+    uri: string;
+    /** PDF-er har ingen forhåndsvisning, så de vises som et ikon i stedet. */
+    isPdf: boolean;
+    key: string | null;
+};
+
+const ACCOUNT_PATTERN = /^\d{4}\.\d{2}\.\d{5}$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_ATTACHMENTS = 10;
+
+/** Photon vil ha `YYYY-MM-DD`; `toISOString` ville gitt gårsdagen før kl. 01 om vinteren. */
+function today(): string {
+    const now = new Date();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `${now.getFullYear()}-${month}-${day}`;
+}
+
+/** Formaterer kontonummer til xxxx.xx.xxxxx mens det skrives. */
+function formatAccountNumber(raw: string): string {
+    const digits = raw.replace(/\D/g, "").slice(0, 11);
+    if (digits.length <= 4) return digits;
+    if (digits.length <= 6) return `${digits.slice(0, 4)}.${digits.slice(4)}`;
+    return `${digits.slice(0, 4)}.${digits.slice(4, 6)}.${digits.slice(6)}`;
+}
+
+export default function NyttUtlegg() {
+    const router = useRouter();
+    const queryClient = useQueryClient();
+    const { isDarkColorScheme } = useColorScheme();
+    const colors = themeColors(isDarkColorScheme);
+
+    const user = useQuery({ queryKey: ["users", "me"], queryFn: me });
+    const options = useQuery({
+        queryKey: ["applications", "options"],
+        queryFn: applicationOptions,
+    });
+
+    const [contactName, setContactName] = useState("");
+    const [contactEmail, setContactEmail] = useState("");
+    const [ccEmail, setCcEmail] = useState<string | null>(null);
+    const [amount, setAmount] = useState("");
+    const [expenseDate, setExpenseDate] = useState(today());
+    const [groupSlug, setGroupSlug] = useState<string | null>(null);
+    const [budgetType, setBudgetType] = useState<BudgetType | null>(null);
+    const [description, setDescription] = useState("");
+    const [accountNumber, setAccountNumber] = useState("");
+    const [receipts, setReceipts] = useState<Receipt[]>([]);
+    const [openPicker, setOpenPicker] = useState<
+        "group" | "budget" | "cc" | null
+    >(null);
+    const [isSuccess, setIsSuccess] = useState(false);
+    // Vises rett over send-knappen. En toast legger seg bak den ugjennomsiktige
+    // headeren på denne skjermen, og feilen ville blitt usynlig.
+    const [formError, setFormError] = useState<string | null>(null);
+
+    // Kontaktfeltene er nesten alltid innsenderen selv, så de fylles ut på
+    // forhånd — men de kan overstyres, siden pengene ikke alltid skal til den
+    // som sender inn.
+    useEffect(() => {
+        if (!user.data) return;
+        setContactName((current) =>
+            current || `${user.data.first_name} ${user.data.last_name}`.trim(),
+        );
+        setContactEmail((current) => current || user.data.email);
+    }, [user.data]);
+
+    const addReceipts = (
+        assets: { uri: string; mimeType?: string | null; fileName?: string | null }[],
+    ) => {
+        setReceipts((current) => {
+            const room = MAX_ATTACHMENTS - current.length;
+            if (room <= 0) {
+                Toast.show({
+                    type: "error",
+                    text1: "For mange kvitteringer",
+                    text2: `Du kan legge ved maks ${MAX_ATTACHMENTS}.`,
+                });
+                return current;
+            }
+            const added = assets.slice(0, room).map((asset) => ({
+                uri: asset.uri,
+                isPdf:
+                    asset.mimeType === "application/pdf" ||
+                    (asset.fileName ?? asset.uri).toLowerCase().endsWith(".pdf"),
+                key: null,
+            }));
+            return [...current, ...added];
+        });
+    };
+
+    const pickFromLibrary = async () => {
+        const result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ["images"],
+            allowsMultipleSelection: true,
+            selectionLimit: MAX_ATTACHMENTS - receipts.length,
+            quality: 0.8,
+        });
+        if (!result.canceled) addReceipts(result.assets);
+    };
+
+    const takePhoto = async () => {
+        const permission = await ImagePicker.requestCameraPermissionsAsync();
+        if (!permission.granted) {
+            Toast.show({
+                type: "error",
+                text1: "Tilgang nektet",
+                text2: "Du må gi tilgang til kameraet for å ta bilde av kvitteringen.",
+            });
+            return;
+        }
+        const result = await ImagePicker.launchCameraAsync({ quality: 0.8 });
+        if (!result.canceled) addReceipts(result.assets);
+    };
+
+    const removeReceipt = (index: number) =>
+        setReceipts((current) => current.filter((_, i) => i !== index));
+
+    /** Første feilmelding, eller null når skjemaet kan sendes. */
+    const validate = (): string | null => {
+        if (!contactName.trim()) return "Fyll inn navn.";
+        if (!contactEmail.trim().includes("@")) return "Fyll inn en gyldig e-post.";
+        const parsedAmount = Number(amount);
+        if (!Number.isInteger(parsedAmount) || parsedAmount <= 0)
+            return "Beløpet må være et helt antall kroner over 0.";
+        if (parsedAmount > 1_000_000) return "Beløpet kan ikke overstige 1 000 000 kr.";
+        if (!DATE_PATTERN.test(expenseDate)) return "Dato må være på formatet ÅÅÅÅ-MM-DD.";
+        if (!groupSlug) return "Velg hvilken gruppe utlegget gjelder.";
+        if (!budgetType) return "Velg budsjett.";
+        if (!description.trim()) return "Beskriv hva utlegget gjelder.";
+        if (!ACCOUNT_PATTERN.test(accountNumber))
+            return "Kontonummer må ha 11 siffer (xxxx.xx.xxxxx).";
+        if (receipts.length === 0) return "Legg ved minst én kvittering.";
+        return null;
+    };
+
+    const submit = useMutation({
+        mutationFn: async () => {
+            // Nøklene beholdes på kvitteringene: feiler selve søknaden på noe
+            // annet, slipper vi å laste opp de samme filene på nytt.
+            const uploaded: Receipt[] = [];
+            for (const receipt of receipts) {
+                uploaded.push(
+                    receipt.key
+                        ? receipt
+                        : { ...receipt, key: await uploadReceipt(receipt.uri) },
+                );
+            }
+            setReceipts(uploaded);
+
+            return createExpense({
+                contactName: contactName.trim(),
+                contactEmail: contactEmail.trim(),
+                ...(ccEmail ? { ccEmail } : {}),
+                amountNok: Number(amount),
+                expenseDate,
+                groupSlug: groupSlug!,
+                budgetType: budgetType!,
+                description: description.trim(),
+                accountNumber,
+                attachmentKeys: uploaded.map((receipt) => receipt.key!),
+            });
+        },
+        onSuccess: (result) => {
+            queryClient.invalidateQueries({
+                queryKey: ["applications", "mine", "expense"],
+            });
+            if (!result.pdfGenerated) {
+                // Utlegget ER sendt inn; bare PDF-en manglet. Det skal ikke se
+                // ut som en feil, men økonomiansvarlig bør vite det.
+                Toast.show({
+                    type: "info",
+                    text1: "Utlegget er sendt inn",
+                    text2: "PDF-en ble ikke generert. Si fra til økonomiansvarlig.",
+                });
+            }
+            setIsSuccess(true);
+        },
+        onError: (error: Error) => {
+            setFormError(error.message);
+            Toast.show({
+                type: "error",
+                text1: "Kunne ikke sende inn",
+                text2: error.message,
+            });
+        },
+    });
+
+    const handleSubmit = () => {
+        const problem = validate();
+        setFormError(problem);
+        if (problem) return;
+        submit.mutate();
+    };
+
+    if (isSuccess) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="flex-1 items-center justify-center px-8">
+                    <View className="w-20 h-20 rounded-full bg-green-100 dark:bg-green-500/20 items-center justify-center mb-6">
+                        <CheckCircle size={40} color="#16a34a" />
+                    </View>
+                    <Text className="text-2xl font-bold text-foreground text-center">
+                        Utlegget er sendt inn
+                    </Text>
+                    <Text className="text-base text-muted-foreground text-center mt-2">
+                        Du får beskjed når det er behandlet.
+                    </Text>
+                    <Pressable
+                        onPress={() => router.back()}
+                        className="h-14 px-8 rounded-2xl bg-primary items-center justify-center mt-8 active:opacity-80"
+                    >
+                        <Text
+                            className="text-base font-semibold text-white"
+                            style={{ fontFamily: "Inter" }}
+                        >
+                            Tilbake til utlegg
+                        </Text>
+                    </Pressable>
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    const inputClass =
+        "h-12 rounded-xl bg-gray-100 dark:bg-secondary/30 px-4 text-base text-foreground";
+
+    const selectedGroup = options.data?.groups.find((g) => g.slug === groupSlug);
+    const selectedBudget = options.data?.budgetTypes.find(
+        (b) => b.value === budgetType,
+    );
+    const selectedCc = options.data?.ccOptions.find((c) => c.email === ccEmail);
+
+    return (
+        <PageWrapper className="flex-1 bg-background">
+            <KeyboardAvoidingView
+                style={{ flex: 1 }}
+                behavior={Platform.OS === "ios" ? "padding" : undefined}
+            >
+                <ScrollView
+                    showsVerticalScrollIndicator={false}
+                    keyboardDismissMode="on-drag"
+                    contentContainerStyle={{ padding: 24, paddingBottom: 120 }}
+                >
+                    {/* Kvitteringer først: det er dem man har telefonen framme for. */}
+                    <SectionHeader title="Kvitteringer" />
+                    <View className="flex-row gap-x-3 mb-3">
+                        <Pressable
+                            onPress={takePhoto}
+                            className="flex-1 flex-row items-center justify-center h-14 rounded-2xl bg-primary active:opacity-80"
+                        >
+                            <Camera size={20} color="#ffffff" />
+                            <Text
+                                className="text-base font-semibold text-white ml-2"
+                                style={{ fontFamily: "Inter" }}
+                            >
+                                Ta bilde
+                            </Text>
+                        </Pressable>
+                        <Pressable
+                            onPress={pickFromLibrary}
+                            className="flex-1 flex-row items-center justify-center h-14 rounded-2xl bg-gray-100 dark:bg-secondary/30 active:opacity-70"
+                        >
+                            <ImagePlus size={20} color={colors.foreground} />
+                            <Text className="text-base font-semibold text-foreground ml-2">
+                                Velg fil
+                            </Text>
+                        </Pressable>
+                    </View>
+
+                    {receipts.length > 0 && (
+                        <View className="flex-row flex-wrap gap-3 mb-2">
+                            {receipts.map((receipt, index) => (
+                                <View key={`${receipt.uri}-${index}`} className="relative">
+                                    {receipt.isPdf ? (
+                                        <View className="w-24 h-24 rounded-xl bg-gray-100 dark:bg-secondary/30 items-center justify-center">
+                                            <FileText size={28} color={colors.mutedForeground} />
+                                        </View>
+                                    ) : (
+                                        <Image
+                                            source={{ uri: receipt.uri }}
+                                            className="w-24 h-24 rounded-xl"
+                                        />
+                                    )}
+                                    <Pressable
+                                        onPress={() => removeReceipt(index)}
+                                        className="absolute -top-2 -right-2 w-7 h-7 rounded-full bg-destructive items-center justify-center"
+                                    >
+                                        <X size={16} color="#ffffff" />
+                                    </Pressable>
+                                </View>
+                            ))}
+                        </View>
+                    )}
+                    <Text className="text-xs text-muted-foreground mb-6">
+                        Minst én kvittering, maks {MAX_ATTACHMENTS}. Bilde eller PDF.
+                    </Text>
+
+                    <SectionHeader title="Utlegget" />
+                    <View className="gap-y-3 mb-6">
+                        <View>
+                            <Text className="text-sm text-muted-foreground mb-1.5">Beløp (kr)</Text>
+                            <TextInput
+                                value={amount}
+                                onChangeText={(text) => setAmount(text.replace(/\D/g, ""))}
+                                keyboardType="number-pad"
+                                placeholder="0"
+                                placeholderTextColor={colors.mutedForeground}
+                                className={inputClass}
+                            />
+                        </View>
+
+                        <View>
+                            <Text className="text-sm text-muted-foreground mb-1.5">
+                                Dato for kjøpet
+                            </Text>
+                            <TextInput
+                                value={expenseDate}
+                                onChangeText={setExpenseDate}
+                                placeholder="ÅÅÅÅ-MM-DD"
+                                placeholderTextColor={colors.mutedForeground}
+                                autoCapitalize="none"
+                                className={inputClass}
+                            />
+                        </View>
+
+                        <Select
+                            label="Gruppe"
+                            value={selectedGroup?.name ?? null}
+                            placeholder={
+                                options.isPending ? "Laster grupper..." : "Velg gruppe"
+                            }
+                            isOpen={openPicker === "group"}
+                            onToggle={() =>
+                                setOpenPicker(openPicker === "group" ? null : "group")
+                            }
+                            items={(options.data?.groups ?? []).map((group) => ({
+                                key: group.slug,
+                                label: group.name,
+                                selected: group.slug === groupSlug,
+                            }))}
+                            onSelect={(key) => {
+                                setGroupSlug(key);
+                                setOpenPicker(null);
+                            }}
+                            colors={colors}
+                        />
+
+                        <Select
+                            label="Budsjett"
+                            value={selectedBudget?.label ?? null}
+                            placeholder="Velg budsjett"
+                            isOpen={openPicker === "budget"}
+                            onToggle={() =>
+                                setOpenPicker(openPicker === "budget" ? null : "budget")
+                            }
+                            items={(options.data?.budgetTypes ?? []).map((budget) => ({
+                                key: budget.value,
+                                label: budget.label,
+                                selected: budget.value === budgetType,
+                            }))}
+                            onSelect={(key) => {
+                                setBudgetType(key as BudgetType);
+                                setOpenPicker(null);
+                            }}
+                            colors={colors}
+                        />
+
+                        <View>
+                            <Text className="text-sm text-muted-foreground mb-1.5">
+                                Hva gjelder utlegget?
+                            </Text>
+                            <TextInput
+                                value={description}
+                                onChangeText={setDescription}
+                                multiline
+                                numberOfLines={4}
+                                maxLength={5000}
+                                textAlignVertical="top"
+                                placeholder="Beskriv kort hva du har kjøpt og hvorfor"
+                                placeholderTextColor={colors.mutedForeground}
+                                className="min-h-24 rounded-xl bg-gray-100 dark:bg-secondary/30 px-4 py-3 text-base text-foreground"
+                            />
+                        </View>
+                    </View>
+
+                    <SectionHeader title="Utbetaling" />
+                    <View className="gap-y-3 mb-6">
+                        <View>
+                            <Text className="text-sm text-muted-foreground mb-1.5">
+                                Kontonummer
+                            </Text>
+                            <TextInput
+                                value={accountNumber}
+                                onChangeText={(text) =>
+                                    setAccountNumber(formatAccountNumber(text))
+                                }
+                                keyboardType="number-pad"
+                                placeholder="1234.56.78901"
+                                placeholderTextColor={colors.mutedForeground}
+                                className={inputClass}
+                            />
+                        </View>
+
+                        <View>
+                            <Text className="text-sm text-muted-foreground mb-1.5">Navn</Text>
+                            <TextInput
+                                value={contactName}
+                                onChangeText={setContactName}
+                                maxLength={200}
+                                placeholder="Ditt navn"
+                                placeholderTextColor={colors.mutedForeground}
+                                className={inputClass}
+                            />
+                        </View>
+
+                        <View>
+                            <Text className="text-sm text-muted-foreground mb-1.5">E-post</Text>
+                            <TextInput
+                                value={contactEmail}
+                                onChangeText={setContactEmail}
+                                keyboardType="email-address"
+                                autoCapitalize="none"
+                                placeholder="din@epost.no"
+                                placeholderTextColor={colors.mutedForeground}
+                                className={inputClass}
+                            />
+                        </View>
+
+                        <Select
+                            label="Kopi til økonomiansvarlig (valgfritt)"
+                            value={selectedCc?.name ?? null}
+                            placeholder="Ingen"
+                            isOpen={openPicker === "cc"}
+                            onToggle={() => setOpenPicker(openPicker === "cc" ? null : "cc")}
+                            items={[
+                                { key: "", label: "Ingen", selected: ccEmail === null },
+                                ...(options.data?.ccOptions ?? []).map((option) => ({
+                                    key: option.email,
+                                    label: option.name,
+                                    selected: option.email === ccEmail,
+                                })),
+                            ]}
+                            onSelect={(key) => {
+                                setCcEmail(key === "" ? null : key);
+                                setOpenPicker(null);
+                            }}
+                            colors={colors}
+                        />
+                    </View>
+
+                    {options.isError && (
+                        <Text className="text-destructive text-sm mb-4">
+                            Kunne ikke laste grupper og budsjetter: {options.error.message}
+                        </Text>
+                    )}
+
+                    {formError && (
+                        <View className="flex-row items-start rounded-xl bg-destructive/10 dark:bg-destructive/20 px-4 py-3 mb-3">
+                            <TriangleAlert size={18} color={colors.destructive} />
+                            <Text className="text-sm text-destructive ml-2 flex-1">
+                                {formError}
+                            </Text>
+                        </View>
+                    )}
+
+                    <Pressable
+                        onPress={handleSubmit}
+                        disabled={submit.isPending}
+                        className={`flex-row items-center justify-center h-14 rounded-2xl bg-primary ${
+                            submit.isPending ? "opacity-60" : "active:opacity-80"
+                        }`}
+                    >
+                        {submit.isPending ? (
+                            <ActivityIndicator color="#ffffff" />
+                        ) : (
+                            <Text
+                                className="text-base font-semibold text-white"
+                                style={{ fontFamily: "Inter" }}
+                            >
+                                Send inn utlegg
+                            </Text>
+                        )}
+                    </Pressable>
+                </ScrollView>
+            </KeyboardAvoidingView>
+        </PageWrapper>
+    );
+}
+
+type SelectItem = { key: string; label: string; selected: boolean };
+
+/**
+ * Nedtrekksliste som utvider seg på stedet.
+ *
+ * En bottom sheet ville tatt over hele skjermen midt i et langt skjema; her
+ * blir feltet stående der det er, og lista legger seg under.
+ */
+function Select({
+    label,
+    value,
+    placeholder,
+    isOpen,
+    onToggle,
+    items,
+    onSelect,
+    colors,
+}: {
+    label: string;
+    value: string | null;
+    placeholder: string;
+    isOpen: boolean;
+    onToggle: () => void;
+    items: SelectItem[];
+    onSelect: (key: string) => void;
+    colors: ReturnType<typeof themeColors>;
+}) {
+    return (
+        <View>
+            <Text className="text-sm text-muted-foreground mb-1.5">{label}</Text>
+            <Pressable
+                onPress={onToggle}
+                className="flex-row items-center justify-between h-12 rounded-xl bg-gray-100 dark:bg-secondary/30 px-4 active:opacity-70"
+            >
+                <Text
+                    className={`text-base ${value ? "text-foreground" : "text-muted-foreground"}`}
+                >
+                    {value ?? placeholder}
+                </Text>
+                <ChevronDown size={18} color={colors.mutedForeground} />
+            </Pressable>
+
+            {isOpen && (
+                <View className="mt-2 rounded-xl bg-gray-100 dark:bg-secondary/30 overflow-hidden">
+                    {items.map((item, index) => (
+                        <Pressable
+                            key={item.key || `item-${index}`}
+                            onPress={() => onSelect(item.key)}
+                            className="flex-row items-center justify-between px-4 py-3.5 active:opacity-70"
+                        >
+                            <Text className="text-base text-foreground flex-1 pr-2">
+                                {item.label}
+                            </Text>
+                            {item.selected && <Check size={18} color={colors.primary} />}
+                        </Pressable>
+                    ))}
+                </View>
+            )}
+        </View>
+    );
+}

--- a/components/utlegg/expenseCard.tsx
+++ b/components/utlegg/expenseCard.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Pressable, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import type { ApplicationStatus, ApplicationSummary } from "@/actions/types";
+
+/**
+ * Statusfargene. Photon sender med `statusLabel` ferdig oversatt, så teksten
+ * hentes derfra og bare fargen bestemmes her.
+ */
+const STATUS_STYLES: Record<ApplicationStatus, string> = {
+    new: "bg-gray-100 dark:bg-secondary/40",
+    in_progress: "bg-amber-100 dark:bg-amber-500/20",
+    approved: "bg-green-100 dark:bg-green-500/20",
+    rejected: "bg-destructive/10 dark:bg-destructive/20",
+};
+
+const STATUS_TEXT: Record<ApplicationStatus, string> = {
+    new: "text-muted-foreground",
+    in_progress: "text-amber-700 dark:text-amber-300",
+    approved: "text-green-700 dark:text-green-300",
+    rejected: "text-destructive",
+};
+
+/** Beløpet lagres i hele kroner, så det formateres uten desimaler. */
+const formatAmount = (amount: number) =>
+    `${amount.toLocaleString("no-NO")} kr`;
+
+const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString("no-NO", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+    });
+
+interface ExpenseCardProps {
+    expense: ApplicationSummary;
+    onPress?: () => void;
+}
+
+const ExpenseCard = React.forwardRef<View, ExpenseCardProps>(
+    ({ expense, onPress }, ref) => {
+        return (
+            <Pressable
+                ref={ref}
+                onPress={onPress}
+                className="bg-gray-100 dark:bg-secondary/30 rounded-2xl p-4 mb-3 active:opacity-70"
+            >
+                <View className="flex-row items-start justify-between">
+                    <View className="flex-1 pr-3">
+                        <Text className="text-base font-semibold text-foreground">
+                            {expense.groupName ?? expense.title}
+                        </Text>
+                        <Text className="text-sm text-muted-foreground mt-0.5">
+                            Sendt {formatDate(expense.createdAt)}
+                        </Text>
+                    </View>
+
+                    <View
+                        className={`rounded-full px-2.5 py-1 ${STATUS_STYLES[expense.status]}`}
+                    >
+                        <Text
+                            className={`text-xs font-semibold ${STATUS_TEXT[expense.status]}`}
+                        >
+                            {expense.statusLabel}
+                        </Text>
+                    </View>
+                </View>
+
+                {expense.amountNok !== null && (
+                    <Text className="text-xl font-bold text-foreground mt-3">
+                        {formatAmount(expense.amountNok)}
+                    </Text>
+                )}
+
+                {expense.handledByName && (
+                    <Text className="text-xs text-muted-foreground mt-2">
+                        Behandlet av {expense.handledByName}
+                    </Text>
+                )}
+            </Pressable>
+        );
+    },
+);
+
+ExpenseCard.displayName = "ExpenseCard";
+
+export function ExpenseCardSkeleton() {
+    return (
+        <View className="bg-gray-100 dark:bg-secondary/30 rounded-2xl p-4 mb-3 animate-pulse">
+            <View className="flex-row items-start justify-between">
+                <View className="flex-1 pr-3">
+                    <View className="h-4 w-40 rounded bg-gray-300 dark:bg-muted" />
+                    <View className="h-3 w-28 rounded bg-gray-300 dark:bg-muted mt-2" />
+                </View>
+                <View className="h-6 w-16 rounded-full bg-gray-300 dark:bg-muted" />
+            </View>
+            <View className="h-6 w-24 rounded bg-gray-300 dark:bg-muted mt-3" />
+        </View>
+    );
+}
+
+export default ExpenseCard;

--- a/lib/icons/Icon.ts
+++ b/lib/icons/Icon.ts
@@ -13,6 +13,7 @@ import { TriangleAlert } from "@/lib/icons/TriangleAlert";
 import { OctagonX } from "@/lib/icons/OctagonX";
 import { Info } from "@/lib/icons/Info";
 import { Scan } from "@/lib/icons/Scan";
+import { ReceiptText } from "@/lib/icons/ReceiptText";
 import { cn } from "../utils";
 
 
@@ -31,6 +32,7 @@ const icons = {
     OctagonX: OctagonX,
     Info: Info,
     Scan: Scan,
+    ReceiptText: ReceiptText,
 }
 
 /**

--- a/lib/icons/ReceiptText.ts
+++ b/lib/icons/ReceiptText.ts
@@ -1,0 +1,4 @@
+import { ReceiptText } from "lucide-react-native";
+import { iconWithClassName } from "./iconWithClassName";
+iconWithClassName(ReceiptText);
+export { ReceiptText };


### PR DESCRIPTION
Fyller den ledige faneplassen ved siden av QR-knappen med en utleggsfane, og stokker om rekkefølgen i navbaren.

## Hvorfor

Utlegg er noe nettsiden gjør dårlig på telefon: kvitteringen ligger allerede i telefonen, men må flyttes over til en PC for å lastes opp. Her fotograferes den og sendes inn med én gang. Photon har allerede hele API-et — appen brukte det bare ikke.

## Fanerekkefølge

Utlegg | Karriere | **QR** | Events | Profil

Den tomme `View`-plassholderen ved siden av QR-knappen er erstattet av den nye fanen. QR-knappen står fortsatt midt i, med to faner på hver side.

## Hva som er lagt til

**API-klient** mot Photons søknads-API:

| Fil | Innhold |
|---|---|
| `actions/types/application.ts` | Typer for søknad, status og budsjett-enum |
| `actions/applications/applications.ts` | `applicationOptions`, `myExpenses` (paginert), `application`, `createExpense` |
| `actions/applications/upload.ts` | Kvitteringsopplasting til `POST /api/assets` |

**Skjermer:**
- `app/(app)/(tabs)/utlegg/index.tsx` — dine utlegg med statusmerke, pull-to-refresh og infinite scroll
- `app/(app)/(tabs)/utlegg/nytt.tsx` — skjema med kamera/filvelger, gruppe- og budsjettvalg, auto-formatert kontonummer
- `components/utlegg/expenseCard.tsx` — kort med statusfarge og skeleton

## Verdt å vite for reviewer

**Kvitteringene lastes opp som `private`.** Photons standard er `public`, og `GET /api/assets/:key` er åpen — en kvittering med kjøpshistorikk ville ellers kunne hentes av hvem som helst som har nøkkelen. Dette er den viktigste linja å ikke miste ved en refaktorering.

**Valideringsfeil vises inline over send-knappen, ikke som toast.** Toasten legger seg bak den ugjennomsiktige headeren på denne skjermen og ville vært usynlig. Det samme gjelder trolig andre skjermer med \`headerShown: true\` — verdt en egen sak, men holdt utenfor her.

**Opplastede asset-nøkler beholdes på hver kvittering.** Feiler selve søknaden på noe annet enn vedleggene, lastes ikke de samme filene opp på nytt ved retry.

**Beløp er heltall NOK.** Photon tar ikke desimaler, så inputen filtrerer bort alt annet enn siffer.

## Testing

Verifisert i iOS-simulator (iPhone 17 Pro) mot ekte Photon-backend:

- Fanelinjen viser riktig rekkefølge, Utlegg markert som aktiv
- Listen henter fra `/applications/mine?type=expense` og viser tom-tilstand
- Gruppedropdownen laster ekte grupper (Beta, Drift, FadderKom, Forvaltningsgruppen, Hovedstyret, IdKom)
- Navn og e-post forhåndsutfylles fra innlogget bruker; dato settes til dagens
- Validering blokkerer innsending og viser feilmeldingen

`npx tsc --noEmit`: 23 feil, identisk med baseline på `main` — ingen nye. `expo lint`: 0 feil.

**Ikke testet:** selve innsendingen. Den ville opprettet en ekte søknad i produksjons-Photon og trigget e-post til økonomiansvarlig, så den bør kjøres én gang manuelt før merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)