### PR TITLE
feat(varsler): varselside med bjelle i headeren

### DIFF
--- a/actions/notifications/notifications.ts
+++ b/actions/notifications/notifications.ts
@@ -1,0 +1,69 @@
+import { apiJson } from "@/lib/api/client";
+import { PhotonNotification, toNotification } from "@/actions/photon";
+import type { Notification } from "@/actions/types";
+
+export const NOTIFICATIONS_PAGE_SIZE = 25;
+
+type PhotonNotificationList = {
+    totalCount: number;
+    pages: number;
+    nextPage: number | null;
+    items: PhotonNotification[];
+};
+
+export type NotificationPage = {
+    items: Notification[];
+    nextPage: number | null;
+    totalCount: number;
+};
+
+/**
+ * Én side med varsler for den innloggede brukeren, nyeste først.
+ *
+ * `isRead` filtrerer på lest/ulest når den er satt, og tar med begge når den
+ * er utelatt.
+ */
+export async function fetchNotifications(
+    page: number,
+    pageSize: number = NOTIFICATIONS_PAGE_SIZE,
+    isRead?: boolean,
+): Promise<NotificationPage> {
+    const query = new URLSearchParams({
+        page: String(page),
+        pageSize: String(pageSize),
+    });
+    if (isRead !== undefined) query.set("isRead", String(isRead));
+
+    const data = await apiJson<PhotonNotificationList>(`/notification?${query}`);
+
+    return {
+        items: data.items.map(toNotification),
+        // `nextPage` peker på en side som ikke finnes når den siste er full
+        // helt på grensen — `page` er nullbasert, mens `pages` er et antall.
+        // En kort side betyr at vi er ferdige, ellers ville lista hentet en
+        // tom side til på bunnen.
+        nextPage: data.items.length < pageSize ? null : data.nextPage,
+        totalCount: data.totalCount,
+    };
+}
+
+/**
+ * Antall uleste varsler.
+ *
+ * Henter én rad og leser `totalCount` — Photon teller med samme filter, så
+ * bjella slipper å laste ned varslene bare for å telle dem.
+ */
+export async function fetchUnreadNotificationCount(): Promise<number> {
+    const data = await apiJson<PhotonNotificationList>(
+        "/notification?page=0&pageSize=1&isRead=false",
+    );
+    return data.totalCount;
+}
+
+/** Markerer ett varsel som lest. */
+export async function markNotificationRead(id: string): Promise<void> {
+    await apiJson(`/notification/${id}/read`, {
+        method: "PATCH",
+        body: JSON.stringify({ isRead: true }),
+    });
+}

--- a/actions/photon.ts
+++ b/actions/photon.ts
@@ -6,7 +6,14 @@
  * migrasjonen mye større og vanskeligere å verifisere. Oversettelsen ligger
  * derfor her, i ett lag, og skjermene er urørt.
  */
-import type { Event, GroupUser, Law, Membership, User } from "@/actions/types";
+import type {
+    Event,
+    GroupUser,
+    Law,
+    Membership,
+    Notification,
+    User,
+} from "@/actions/types";
 
 export type PhotonUser = {
     id: string;
@@ -222,3 +229,28 @@ export const classRangeLabel = (start: string, end: string): string => {
     if (start === "alumni") return "Alumni";
     return "";
 };
+
+export type PhotonNotification = {
+    id: string;
+    title: string;
+    description: string;
+    link?: string | null;
+    isRead: boolean;
+    createdAt: string;
+};
+
+/**
+ * Varsler har ingen Lepton-form å oversette til — feltene er Photons egne.
+ * Kartleggingen ligger her likevel, sånn at skjermene fortsatt bare kjenner
+ * `Notification` og ikke svarformen fra API-et.
+ */
+export const toNotification = (
+    notification: PhotonNotification,
+): Notification => ({
+    id: notification.id,
+    title: notification.title,
+    description: notification.description,
+    link: notification.link ?? null,
+    isRead: notification.isRead,
+    createdAt: notification.createdAt,
+});

--- a/actions/types/index.ts
+++ b/actions/types/index.ts
@@ -8,3 +8,4 @@ export * from "./registration";
 export * from "./payment";
 export * from "./fine";
 export * from "./application";
+export * from "./notification";

--- a/actions/types/notification.ts
+++ b/actions/types/notification.ts
@@ -1,0 +1,16 @@
+/**
+ * Et varsel slik appen viser det.
+ *
+ * Dette er den eneste typen som ikke er arvet fra Leptons snake_case: varsler
+ * fantes ikke i appen før Photon, så navnene er Photons egne.
+ */
+export type Notification = {
+    id: string;
+    title: string;
+    description: string;
+    /** Nettsidelenke varselet peker på, eller null. Oversettes av `toAppRoute`. */
+    link: string | null;
+    isRead: boolean;
+    /** ISO 8601. */
+    createdAt: string;
+};

--- a/app/(app)/(modals)/_layout.tsx
+++ b/app/(app)/(modals)/_layout.tsx
@@ -36,6 +36,25 @@ export default function ModalsLayout() {
                 }}
             />
             <Stack.Screen
+                name="varsler"
+                options={{
+                    ...modalScreenOptions,
+                    title: "Varsler",
+                    headerShown: true,
+                    // Åpnes fra bjella i en fane, så den er første skjerm i
+                    // denne stacken og får ingen tilbakeknapp av seg selv.
+                    headerLeft: () => (
+                        <Pressable
+                            onPress={() => router.back()}
+                            className="flex-row items-center active:opacity-70 mr-2"
+                        >
+                            <ChevronLeft size={24} color={backColor} />
+                            <Text className="text-base text-foreground">Tilbake</Text>
+                        </Pressable>
+                    ),
+                }}
+            />
+            <Stack.Screen
                 name="arrangement/[arrangementId]"
                 options={{
                     ...modalScreenOptions,

--- a/app/(app)/(modals)/varsler.tsx
+++ b/app/(app)/(modals)/varsler.tsx
@@ -1,0 +1,258 @@
+import {
+    fetchNotifications,
+    markNotificationRead,
+} from "@/actions/notifications/notifications";
+import type { Notification } from "@/actions/types";
+import { Text } from "@/components/ui/text";
+import PageWrapper from "@/components/ui/pagewrapper";
+import { toAppRoute } from "@/lib/notifications/link";
+import { decrementUnreadCount, notificationKeys } from "@/lib/notifications/queries";
+import { themeColors } from "@/lib/theme/colors";
+import useRefresh from "@/lib/useRefresh";
+import { useColorScheme } from "@/lib/useColorScheme";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import { nb } from "date-fns/locale";
+import { useRouter } from "expo-router";
+import { BellOff } from "lucide-react-native";
+import { useCallback, useEffect, useRef } from "react";
+import {
+    ActivityIndicator,
+    FlatList,
+    Pressable,
+    View,
+    type ViewToken,
+} from "react-native";
+
+/** Hvor mye av raden som må være synlig, og hvor lenge, før den er «sett». */
+const VIEWABILITY = {
+    itemVisiblePercentThreshold: 60,
+    minimumViewTime: 400,
+};
+
+export default function Varsler() {
+    const router = useRouter();
+    const queryClient = useQueryClient();
+    const { isDarkColorScheme } = useColorScheme();
+    const refreshControl = useRefresh([...notificationKeys.list]);
+
+    const {
+        data,
+        isPending,
+        isError,
+        error,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+        refetch,
+    } = useInfiniteQuery({
+        queryKey: notificationKeys.list,
+        queryFn: ({ pageParam }) => fetchNotifications(pageParam),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => lastPage.nextPage,
+    });
+
+    const notifications = data?.pages.flatMap((page) => page.items) ?? [];
+
+    /**
+     * Hvilke varsler som var uleste da skjermen ble åpnet.
+     *
+     * Prikken tegnes fra dette settet og ikke fra `isRead`. Ellers ville den
+     * forsvunnet under fingeren idet varselet ble markert som lest — brukeren
+     * skal rekke å se hva som var nytt, og prikken skal først være borte
+     * neste gang lista åpnes.
+     */
+    const unreadAtOpen = useRef(new Set<string>());
+    for (const notification of notifications) {
+        if (!notification.isRead) unreadAtOpen.current.add(notification.id);
+    }
+
+    /** Varsler vi allerede har sendt lesekvittering for, så det skjer én gang. */
+    const marked = useRef(new Set<string>());
+
+    const markSeen = useCallback(
+        (notification: Notification) => {
+            if (notification.isRead || marked.current.has(notification.id)) return;
+            marked.current.add(notification.id);
+
+            markNotificationRead(notification.id)
+                .then(() => decrementUnreadCount(queryClient))
+                // Et mislykket kall skal kunne prøves på nytt når raden ses
+                // igjen — å bli stående ulest er bedre enn en prikk som er
+                // borte lokalt, men fortsatt telles av serveren.
+                .catch(() => marked.current.delete(notification.id));
+        },
+        [queryClient],
+    );
+
+    // FlatList godtar ikke at `onViewableItemsChanged` bytter identitet, så
+    // den stabile funksjonen leser den ferske handleren gjennom en ref.
+    const handleViewable = useRef<(items: ViewToken[]) => void>(() => {});
+    handleViewable.current = (viewableItems) => {
+        for (const entry of viewableItems) {
+            if (entry.item) markSeen(entry.item as Notification);
+        }
+    };
+    const onViewableItemsChanged = useRef(
+        ({ viewableItems }: { viewableItems: ViewToken[] }) =>
+            handleViewable.current(viewableItems),
+    ).current;
+
+    // Lista holdes urørt mens skjermen er åpen (se `unreadAtOpen`). Sannheten
+    // hentes når brukeren går ut igjen.
+    useEffect(
+        () => () => {
+            queryClient.invalidateQueries({ queryKey: notificationKeys.list });
+        },
+        [queryClient],
+    );
+
+    const openNotification = async (notification: Notification) => {
+        markSeen(notification);
+
+        const route = await toAppRoute(notification.link);
+        if (route) router.push(route as never);
+    };
+
+    if (isPending) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="px-4 pt-4">
+                    {[0, 1, 2, 3, 4].map((i) => (
+                        <NotificationSkeleton key={i} />
+                    ))}
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    if (isError) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="flex-1 items-center justify-center px-6">
+                    <Text className="text-base text-destructive text-center">
+                        {error.message}
+                    </Text>
+                    <Pressable
+                        onPress={() => refetch()}
+                        className="mt-6 h-12 px-6 rounded-2xl items-center justify-center bg-primary active:opacity-80"
+                    >
+                        <Text className="text-white text-base font-semibold">
+                            Prøv igjen
+                        </Text>
+                    </Pressable>
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    return (
+        <PageWrapper className="flex-1 bg-background">
+            <FlatList
+                data={notifications}
+                keyExtractor={(item) => item.id}
+                refreshControl={refreshControl}
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{
+                    paddingBottom: 40,
+                    flexGrow: 1,
+                }}
+                onViewableItemsChanged={onViewableItemsChanged}
+                viewabilityConfig={VIEWABILITY}
+                onEndReached={() => {
+                    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+                }}
+                onEndReachedThreshold={0.4}
+                ItemSeparatorComponent={() => (
+                    <View className="h-px bg-border dark:bg-muted ml-4" />
+                )}
+                ListEmptyComponent={
+                    <View className="flex-1 items-center justify-center px-10">
+                        <BellOff
+                            size={40}
+                            color={themeColors(isDarkColorScheme).mutedForeground}
+                        />
+                        <Text className="text-base font-semibold text-foreground mt-4">
+                            Ingen varsler
+                        </Text>
+                        <Text className="text-sm text-muted-foreground text-center mt-1">
+                            Her dukker det opp beskjeder om arrangementer, bøter
+                            og søknader.
+                        </Text>
+                    </View>
+                }
+                ListFooterComponent={
+                    isFetchingNextPage ? (
+                        <View className="py-6">
+                            <ActivityIndicator size="small" />
+                        </View>
+                    ) : null
+                }
+                renderItem={({ item }) => (
+                    <NotificationRow
+                        notification={item}
+                        isNew={unreadAtOpen.current.has(item.id)}
+                        onPress={() => openNotification(item)}
+                    />
+                )}
+            />
+        </PageWrapper>
+    );
+}
+
+function NotificationRow({
+    notification,
+    isNew,
+    onPress,
+}: {
+    notification: Notification;
+    isNew: boolean;
+    onPress: () => void;
+}) {
+    return (
+        <Pressable
+            onPress={onPress}
+            className={`flex-row px-4 py-4 active:opacity-70 ${isNew ? "bg-primary/5 dark:bg-primary/10" : ""}`}
+        >
+            {/* Prikken har sin egen kolonne, slik at teksten står på linje
+                enten varselet er nytt eller ikke. */}
+            <View className="w-4 pt-1.5">
+                {isNew ? (
+                    <View className="w-2.5 h-2.5 rounded-full bg-primary" />
+                ) : null}
+            </View>
+
+            <View className="flex-1">
+                <Text
+                    className={`text-base text-foreground ${isNew ? "font-semibold" : ""}`}
+                >
+                    {notification.title}
+                </Text>
+                <Text className="text-sm text-muted-foreground mt-0.5">
+                    {notification.description}
+                </Text>
+                <Text className="text-xs text-muted-foreground mt-1.5">
+                    {formatDistanceToNow(new Date(notification.createdAt), {
+                        locale: nb,
+                        addSuffix: true,
+                    })}
+                </Text>
+            </View>
+        </Pressable>
+    );
+}
+
+function NotificationSkeleton() {
+    return (
+        <View className="flex-row py-4">
+            <View className="w-4 pt-1.5">
+                <View className="w-2.5 h-2.5 rounded-full bg-muted animate-pulse" />
+            </View>
+            <View className="flex-1">
+                <View className="h-4 w-2/3 rounded bg-muted animate-pulse" />
+                <View className="h-3 w-full rounded bg-muted animate-pulse mt-2.5" />
+                <View className="h-3 w-1/4 rounded bg-muted animate-pulse mt-2.5" />
+            </View>
+        </View>
+    );
+}

--- a/app/(app)/(tabs)/arrangementer/_layout.tsx
+++ b/app/(app)/(tabs)/arrangementer/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from "expo-router";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 
 export default function ArrangementerLayout() {
     return (
@@ -9,6 +10,7 @@ export default function ArrangementerLayout() {
                     headerShown: true,
                     title: "Arrangementer",
                     headerTitleAlign: "center",
+                    headerRight: () => <NotificationBell />,
                 }}
             />
         </Stack>

--- a/app/(app)/(tabs)/bot/_layout.tsx
+++ b/app/(app)/(tabs)/bot/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from "expo-router";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 
 export default function BotLayout() {
     return (
@@ -13,6 +14,7 @@ export default function BotLayout() {
                     headerShown: true,
                     title: "Velg gruppe",
                     headerTitleAlign: "center",
+                    headerRight: () => <NotificationBell />,
                 }}
             />
         </Stack>

--- a/app/(app)/(tabs)/karriere/_layout.tsx
+++ b/app/(app)/(tabs)/karriere/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from "expo-router";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 
 export default function KarriereLayout() {
     return (
@@ -14,6 +15,7 @@ export default function KarriereLayout() {
                     title: "Jobbannonser",
                     headerBackTitle: "Tilbake",
                     headerTitleAlign: "center",
+                    headerRight: () => <NotificationBell />,
                 }}
             />
         </Stack>

--- a/app/(app)/(tabs)/profil/_layout.tsx
+++ b/app/(app)/(tabs)/profil/_layout.tsx
@@ -3,6 +3,7 @@ import { Pressable, View } from "react-native";
 import { themeColors } from "@/lib/theme/colors";
 import { useColorScheme } from "@/lib/useColorScheme";
 import { QrCode } from "lucide-react-native";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 
 export default function ProfilLayout() {
     const router = useRouter();
@@ -20,8 +21,9 @@ export default function ProfilLayout() {
                     headerShown: true,
                     title: "Profil",
                     headerTitleAlign: "center",
-                    // QR-koden hører hjemme her — den er det eneste som ligger i headeren.
-                    headerRight: () => (
+                    // QR-koden lå til høyre før bjella kom. Høyre side er nå
+                    // varsler på alle fanene, så QR-en flyttet til venstre.
+                    headerLeft: () => (
                         <Pressable
                             onPress={() => router.push("/(app)/(modals)/qrmodal")}
                             hitSlop={8}
@@ -38,6 +40,7 @@ export default function ProfilLayout() {
                             )}
                         </Pressable>
                     ),
+                    headerRight: () => <NotificationBell />,
                 }}
             />
         </Stack>

--- a/app/(app)/(tabs)/utlegg/_layout.tsx
+++ b/app/(app)/(tabs)/utlegg/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack } from "expo-router";
+import { NotificationBell } from "@/components/notifications/NotificationBell";
 
 export default function UtleggLayout() {
     return (
@@ -14,6 +15,7 @@ export default function UtleggLayout() {
                     title: "Utlegg",
                     headerBackTitle: "Tilbake",
                     headerTitleAlign: "center",
+                    headerRight: () => <NotificationBell />,
                 }}
             />
             <Stack.Screen

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -1,0 +1,62 @@
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Bell } from "lucide-react-native";
+import { Pressable, View } from "react-native";
+import { fetchUnreadNotificationCount } from "@/actions/notifications/notifications";
+import { notificationKeys } from "@/lib/notifications/queries";
+import { themeColors } from "@/lib/theme/colors";
+import { useColorScheme } from "@/lib/useColorScheme";
+
+/**
+ * Bjella i headeren. Ligger øverst til høyre på alle fanene og åpner
+ * varsellista.
+ *
+ * Prikken viser bare *at* det finnes uleste, ikke hvor mange — antallet er
+ * ikke noe brukeren kan gjøre noe med, og et tall som står og teller opp gjør
+ * headeren urolig.
+ */
+export function NotificationBell() {
+    const router = useRouter();
+    const { isDarkColorScheme } = useColorScheme();
+
+    const unread = useQuery({
+        queryKey: notificationKeys.unreadCount,
+        queryFn: fetchUnreadNotificationCount,
+        // Bjella står montert så lenge fanen lever, så uten dette ville
+        // antallet vært fra første gang skjermen ble åpnet. Varsellista
+        // oppdaterer tallet selv når den markerer noe som lest.
+        staleTime: 60_000,
+        refetchOnMount: "always",
+    });
+
+    const hasUnread = (unread.data ?? 0) > 0;
+    const colors = themeColors(isDarkColorScheme);
+
+    return (
+        <Pressable
+            onPress={() => router.push("/(app)/(modals)/varsler")}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={hasUnread ? "Varsler, uleste" : "Varsler"}
+            className="w-10 h-10 items-center justify-center"
+        >
+            {({ pressed }) => (
+                <View style={{ opacity: pressed ? 0.7 : 1 }}>
+                    <Bell size={22} strokeWidth={2} color={colors.foreground} />
+                    {hasUnread ? (
+                        <View
+                            className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-primary"
+                            style={{
+                                // Kanten skiller prikken fra bjelleikonet den
+                                // ligger oppå. Den må ha headerens farge, og
+                                // den er ikke en klasse her.
+                                borderWidth: 1.5,
+                                borderColor: colors.background,
+                            }}
+                        />
+                    ) : null}
+                </View>
+            )}
+        </Pressable>
+    );
+}

--- a/components/notifications/PushNotifications.tsx
+++ b/components/notifications/PushNotifications.tsx
@@ -1,9 +1,12 @@
 import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
 import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/context/auth";
 import { toAppRoute } from "@/lib/notifications/link";
+import { notificationKeys } from "@/lib/notifications/queries";
 import { registerForPushNotifications } from "@/lib/notifications/push";
+import { markPushNotificationRead } from "@/lib/notifications/read-push";
 
 /**
  * Kobler appen til push-varsler: melder telefonen på når noen er logget inn,
@@ -16,6 +19,7 @@ export function PushNotifications() {
     const { authState } = useAuth();
     const authenticated = authState?.auhtenticated ?? false;
     const router = useRouter();
+    const queryClient = useQueryClient();
 
     // Dekker både trykk mens appen kjører og trykket som startet appen fra
     // helt lukket tilstand — det siste finnes ikke som hendelse å lytte på.
@@ -38,11 +42,29 @@ export function PushNotifications() {
         if (handled.current === id) return;
         handled.current = id;
 
-        const { link } = lastResponse.notification.request.content.data as {
+        const content = lastResponse.notification.request.content;
+        const { link, notificationId } = content.data as {
             link?: string | null;
+            notificationId?: string | null;
         };
 
         let cancelled = false;
+
+        // Å trykke på varselet er å ha sett det, så det markeres som lest selv
+        // om appen ikke har en skjerm å sende brukeren til.
+        markPushNotificationRead({
+            notificationId,
+            title: content.title,
+            body: content.body,
+            link,
+        }).then((marked) => {
+            if (marked && !cancelled) {
+                queryClient.invalidateQueries({
+                    queryKey: notificationKeys.list,
+                });
+            }
+        });
+
         toAppRoute(link).then((route) => {
             if (!cancelled && route) router.push(route as never);
         });
@@ -50,7 +72,7 @@ export function PushNotifications() {
         return () => {
             cancelled = true;
         };
-    }, [authenticated, lastResponse, router]);
+    }, [authenticated, lastResponse, router, queryClient]);
 
     return null;
 }

--- a/lib/notifications/queries.ts
+++ b/lib/notifications/queries.ts
@@ -1,0 +1,25 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Nøklene varsellista og bjella deler.
+ *
+ * `unreadCount` ligger med vilje under `list` sin nøkkel: å invalidere
+ * `["notifications"]` treffer da begge, som er riktig hver gang noe leses.
+ */
+export const notificationKeys = {
+    list: ["notifications"] as const,
+    unreadCount: ["notifications", "unread"] as const,
+};
+
+/**
+ * Teller ned antallet uleste uten å spørre serveren.
+ *
+ * Brukes mens varsellista er åpen: der markeres varsler som lest ett og ett
+ * etter hvert som de kommer til syne, og en invalidering per varsel ville
+ * blitt et kall til Photon per rad brukeren scroller forbi.
+ */
+export function decrementUnreadCount(queryClient: QueryClient): void {
+    queryClient.setQueryData<number>(notificationKeys.unreadCount, (count) =>
+        Math.max(0, (count ?? 1) - 1),
+    );
+}

--- a/lib/notifications/read-push.ts
+++ b/lib/notifications/read-push.ts
@@ -1,0 +1,58 @@
+import {
+    fetchNotifications,
+    markNotificationRead,
+} from "@/actions/notifications/notifications";
+
+/** Hvor mange uleste vi leter gjennom etter det som ble trykket på. */
+const SEARCH_PAGE_SIZE = 50;
+
+/**
+ * Markerer varselet bak et trykket push-varsel som lest.
+ *
+ * Photon legger `notificationId` i nyttelasten, og da er det bare å markere
+ * den raden. Varsler som lå i køen før det endepunktet ble utplassert bærer
+ * ingen id, og for dem letes det i de uleste etter samme tittel og tekst. Er
+ * det flere like, vinner det nyeste — lista kommer sortert med det først.
+ *
+ * Gir `true` når noe faktisk ble markert, slik at den som kaller vet om
+ * antallet uleste er endret.
+ */
+export async function markPushNotificationRead(content: {
+    notificationId?: string | null;
+    title?: string | null;
+    body?: string | null;
+    link?: string | null;
+}): Promise<boolean> {
+    if (content.notificationId) {
+        try {
+            await markNotificationRead(content.notificationId);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    if (!content.title) return false;
+
+    try {
+        const unread = await fetchNotifications(0, SEARCH_PAGE_SIZE, false);
+
+        const match = unread.items.find(
+            (notification) =>
+                notification.title === content.title &&
+                notification.description === (content.body ?? "") &&
+                // Lenken sammenlignes bare når push-varselet har en. Eldre
+                // varsler i køen kan ha blitt sendt uten.
+                (!content.link || notification.link === content.link),
+        );
+
+        if (!match) return false;
+
+        await markNotificationRead(match.id);
+        return true;
+    } catch {
+        // Et varsel som ikke rekker å bli markert som lest er ikke verdt å
+        // avbryte navigasjonen for — brukeren er på vei inn i appen.
+        return false;
+    }
+}


### PR DESCRIPTION
## Hva

En varselside i appen, med bjelle øverst til høyre på alle fanene.

Push-varsler var ferskvare: traff du ikke trykket med en gang, var beskjeden borte fra appen. Photon har lagret varslene hele tiden (`GET /api/notification`), det fantes bare ingen skjerm som viste dem.

## Slik oppfører det seg

- Bjella ligger i headeren på alle fem fanene og får en blå prikk når det finnes uleste. Antallet vises ikke — det er ikke noe brukeren kan gjøre noe med, og et tall som teller opp gjør headeren urolig.
- Varsellista glir inn fra høyre (`(modals)`-gruppa, `slide_from_right`).
- Et varsel markeres som lest når raden faktisk har vært synlig i 400 ms (`onViewableItemsChanged`) — ikke bare fordi den ble hentet ned.
- Prikken blir stående så lenge du er inne på sida, selv om varselet allerede er markert lest på serveren. Ellers ville den forsvunnet under fingeren, og poenget med den er å vise hva som var nytt. Neste gang lista åpnes er den borte.
- Trykk på et varsel markerer det som lest og åpner riktig skjerm via `toAppRoute` når lenken peker på noe appen har.
- Å åpne appen ved å trykke på et push-varsel regnes som lest.
- QR-koden på profilen er flyttet til venstre for å gi plass til bjella.

## Avhengighet

Push-nyttelasten bærer varselets id først etter TIHLDE/Photon#527. Fram til den er utplassert finner appen igjen varselet ved å lete blant de uleste og matche på tittel, tekst og lenke. Den fallbacken er beholdt med vilje: varsler som allerede lå i køen når appen oppdateres bærer ingen id. Den kan fjernes når #527 har vært ute en stund.

## Farge

Prikken bruker `bg-primary` (TIHLDE-blå). Paletten har ingen egen «cta-blå» — skal den være en klarere iOS-blå må vi legge inn en ny variabel i `global.css` og `lib/theme/colors.ts`.

## Testet

- `npx tsc --noEmit` — ingen feil i noen av de nye eller endrede filene (de 15 gjenværende ligger i urørte filer og fantes fra før)
- `npx expo lint` — rent for filene i denne PR-en
- `npx expo export --platform ios` — hele bundlen bygger (4808 moduler)

**Ikke kjørt i simulator.** Repoet har ingen `ios/`-mappe, så det krever en full `expo prebuild` + native build. Bjella, lesemarkeringen og prikkens levetid bør sjekkes på ekte enhet før merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)