### PR TITLE
chore(eas): hold worktrees og git-historikk utenfor byggarkivet

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,65 @@
+# Hva som IKKE lastes opp til EAS Build.
+#
+# Viktig: finnes denne fila, bruker EAS den i stedet for `.gitignore` — ikke i
+# tillegg til. Alt som skal holdes utenfor arkivet må derfor stå her, også det
+# som allerede står i `.gitignore`.
+#
+# Bakgrunn: bygg 7 lastet opp 622 MB. `.claude/worktrees/` er bare ekskludert
+# i `.git/info/exclude`, som er lokal og ikke følger med repoet, og den mappa
+# er på flere gigabyte fordi hvert worktree har sin egen `node_modules` og
+# prebuild.
+
+# Agent-worktrees. Hvert av dem er en full kopi av repoet.
+.claude/
+
+# Git-historikken er 246 MB og utgjorde mesteparten av de 622 MB-ene.
+# Byggeren pakker bare ut arkivet og kjører `npm ci` og prebuild — den rører
+# aldri historikken. Commit-en bygget kommer fra leses lokalt av eas-cli før
+# opplasting, så den blir med uansett.
+#
+# Skulle et framtidig byggsteg trenge git-metadata, er det denne linja som må
+# vekk.
+.git/
+
+# Avhengigheter — installeres av byggeren selv
+node_modules/
+
+# Expo
+.expo/
+dist/
+web-build/
+expo-env.d.ts
+
+# ios/ og android/ genereres av `expo prebuild` på byggeren (CNG).
+# Lokale kopier fra `expo run:*` skal ikke sendes med.
+/ios
+/android
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+.DS_Store
+*.pem
+
+# lokale env-filer
+.env*.local
+
+# typescript
+*.tsbuildinfo
+
+app-example
+
+# Google Cloud Platform
+service-account-file.json


### PR DESCRIPTION
## Hva

En `.easignore`, så EAS Build slipper å laste opp ting byggeren ikke bruker.

## Hvorfor

Bygg 7 lastet opp **622 MB**. To ting sto for nesten alt:

- **`.claude/worktrees/`** — flere gigabyte. Hvert agent-worktree er en full kopi av repoet med sin egen `node_modules` og prebuild. Mappa er bare ekskludert i `.git/info/exclude`, som er lokal og ikke følger med repoet, så EAS så den aldri som ignorert.
- **`.git/`** — 246 MB historikk.

Målt på arbeidstreet: 622 MB → **~2,3 MB**.

## Merk

**EAS bruker `.easignore` i stedet for `.gitignore`, ikke i tillegg til.** Fila er derfor en kopi av `.gitignore` pluss `.claude/` og `.git/`. De to må holdes i takt — legger noen til noe i `.gitignore` som ikke skal opp til EAS, må det inn her også. Det står som kommentar øverst i fila.

At `.git/` kan utelates hviler på at byggeren bare pakker ut arkivet og kjører `npm ci` + prebuild; den rører aldri historikken, og commit-en bygget kommer fra leses lokalt av eas-cli før opplasting. Skulle et framtidig byggsteg trenge git-metadata, er det den ene linja som må vekk.

## Testet

Ikke verifisert med et ekte bygg — det koster en byggekjøring. Tallene over er målt på arbeidstreet med samme ekskluderingsregler som fila. Neste bygg bekrefter det: se etter «Your project archive is …» i loggen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)