### PR TITLE
fix(bilder): vis forsidebilder i 21:9 som i Photon

### DIFF
--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -1,7 +1,7 @@
 import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { View, Image, ActivityIndicator, Pressable } from "react-native";
+import { View, ActivityIndicator, Pressable } from "react-native";
 import MarkdownView from "@/components/ui/MarkdownView";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import PageWrapper from "@/components/ui/pagewrapper";
@@ -20,7 +20,7 @@ import { BottomSheetBackdrop, BottomSheetFlatList, BottomSheetModal, BottomSheet
 import { publicEventParticipants } from "@/actions/events/participants";
 import { InteropBottomSheetModal } from "@/lib/interopBottomSheet";
 import UserCard from "@/components/ui/userCard";
-import ImageMissing from "@/components/ui/imageMissing";
+import CoverImage, { COVER_IMAGE_FRAME } from "@/components/ui/coverImage";
 import useRefresh from "@/lib/useRefresh";
 import { SectionHeader } from "@/components/ui/section-header";
 import { useColorScheme } from "@/lib/useColorScheme";
@@ -76,7 +76,7 @@ function DetailSkeleton() {
         <PageWrapper className="flex-1 bg-background">
             <ScrollView showsVerticalScrollIndicator={false}>
                 {/* Image skeleton */}
-                <View className="w-full aspect-[16/9] bg-muted dark:bg-secondary/40 animate-pulse" />
+                <View className={`${COVER_IMAGE_FRAME} bg-muted dark:bg-secondary/40 animate-pulse`} />
 
                 <View className="px-6 pt-5">
                     {/* Title skeleton */}
@@ -265,17 +265,7 @@ export default function ArrangementSide() {
                     contentContainerStyle={{ paddingBottom: 40 }}
                 >
                     {/* Hero image */}
-                    <View className="w-full aspect-[16/9] overflow-hidden">
-                        {event.data.image ? (
-                            <Image
-                                source={{ uri: event.data.image }}
-                                className="w-full h-full"
-                                resizeMode="cover"
-                            />
-                        ) : (
-                            <ImageMissing />
-                        )}
-                    </View>
+                    <CoverImage uri={event.data.image} />
 
                     <View className="px-6">
                         {/* Title section */}

--- a/app/(app)/(modals)/boter/[groupSlug]/bekreft.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/bekreft.tsx
@@ -1,3 +1,4 @@
+import { avatarImageUrl } from "@/lib/images";
 import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import PageWrapper from "@/components/ui/pagewrapper";
@@ -204,8 +205,11 @@ export default function ConfirmFine() {
                                 >
                                     {user.image ? (
                                         <Image
-                                            source={{ uri: user.image }}
+                                            source={{
+                                                uri: avatarImageUrl(user.image),
+                                            }}
                                             className="w-12 h-12 rounded-full"
+                                            resizeMode="cover"
                                         />
                                     ) : (
                                         <View className="w-12 h-12 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">

--- a/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
@@ -1,3 +1,4 @@
+import { avatarImageUrl } from "@/lib/images";
 import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import PageWrapper from "@/components/ui/pagewrapper";
@@ -165,8 +166,9 @@ export default function UserSelection() {
                         >
                             {user.image ? (
                                 <Image
-                                    source={{ uri: user.image }}
+                                    source={{ uri: avatarImageUrl(user.image) }}
                                     className="w-10 h-10 rounded-full"
+                                    resizeMode="cover"
                                 />
                             ) : (
                                 <View className="w-10 h-10 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">

--- a/app/(app)/(tabs)/bot/index.tsx
+++ b/app/(app)/(tabs)/bot/index.tsx
@@ -1,3 +1,4 @@
+import { avatarImageUrl } from "@/lib/images";
 import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import PageWrapper from "@/components/ui/pagewrapper";
@@ -57,8 +58,11 @@ export default function MembershipSelection() {
                     >
                         {membership.group.image ? (
                             <Image
-                                source={{ uri: membership.group.image }}
+                                source={{
+                                    uri: avatarImageUrl(membership.group.image),
+                                }}
                                 className="w-12 h-12 rounded-full"
+                                resizeMode="cover"
                             />
                         ) : (
                             <View className="w-12 h-12 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">

--- a/app/(app)/(tabs)/karriere/[karriereId].tsx
+++ b/app/(app)/(tabs)/karriere/[karriereId].tsx
@@ -4,7 +4,8 @@ import { classRangeLabel } from "@/actions/photon";
 import { Text } from "@/components/ui/text";
 import { useQuery } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams } from "expo-router";
-import { Image, Pressable, ScrollView, View } from "react-native";
+import { Pressable, ScrollView, View } from "react-native";
+import CoverImage, { COVER_IMAGE_FRAME } from "@/components/ui/coverImage";
 import * as WebBrowser from 'expo-web-browser';
 import MarkdownView from "@/components/ui/MarkdownView";
 import PageWrapper from "@/components/ui/pagewrapper";
@@ -56,7 +57,7 @@ function DetailSkeleton() {
         <PageWrapper className="flex-1 bg-background">
             <ScrollView showsVerticalScrollIndicator={false}>
                 {/* Image skeleton */}
-                <View className="w-full aspect-[16/9] bg-muted dark:bg-secondary/40 animate-pulse" />
+                <View className={`${COVER_IMAGE_FRAME} bg-muted dark:bg-secondary/40 animate-pulse`} />
 
                 <View className="px-6 pt-5">
                     {/* Title skeleton */}
@@ -152,13 +153,7 @@ export default function Karriereside() {
                 >
                     {/* Hero image */}
                     {jobpost.data.image && (
-                        <View className="w-full aspect-[16/9] overflow-hidden">
-                            <Image
-                                className="w-full h-full"
-                                resizeMode="cover"
-                                source={{ uri: jobpost.data.image }}
-                            />
-                        </View>
+                        <CoverImage uri={jobpost.data.image} />
                     )}
 
                     <View className="px-6">

--- a/app/(app)/(tabs)/profil/index.tsx
+++ b/app/(app)/(tabs)/profil/index.tsx
@@ -1,3 +1,4 @@
+import { avatarImageUrl } from "@/lib/images";
 import { themeColors } from "@/lib/theme/colors";
 import me, { myEvents } from "@/actions/users/me";
 import PageWrapper from "@/components/ui/pagewrapper";
@@ -120,7 +121,8 @@ export default function Profil() {
                         {user.data.image ? (
                             <Image
                                 className="w-28 h-28 rounded-full"
-                                source={{ uri: user.data.image }}
+                                source={{ uri: avatarImageUrl(user.data.image) }}
+                                resizeMode="cover"
                             />
                         ) : (
                             <View className="w-28 h-28 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">

--- a/components/arrangement/eventCard.tsx
+++ b/components/arrangement/eventCard.tsx
@@ -1,8 +1,8 @@
 import { themeColors } from "@/lib/theme/colors";
 import React from 'react';
-import { View, Image, Pressable } from 'react-native';
+import { View, Pressable } from 'react-native';
 import { Text } from "@/components/ui/text";
-import ImageMissing from '../ui/imageMissing';
+import CoverImage, { COVER_IMAGE_FRAME } from '../ui/coverImage';
 import { useColorScheme } from "@/lib/useColorScheme";
 import { CalendarDays, MapPin, Clock } from "lucide-react-native";
 
@@ -70,17 +70,7 @@ const EventCard = ({
     return (
         <Pressable onPress={onPress} className="pb-7 active:opacity-80">
             {/* Full-width image */}
-            <View className="w-full aspect-[2/1] overflow-hidden">
-                {image ? (
-                    <Image
-                        source={{ uri: image }}
-                        className="w-full h-full"
-                        resizeMode="cover"
-                    />
-                ) : (
-                    <ImageMissing />
-                )}
-            </View>
+            <CoverImage uri={image} />
 
             {/* Content */}
             <View className="px-4 pt-3.5">
@@ -129,7 +119,7 @@ const EventCardSkeleton = () => {
     return (
         <View className="pb-7">
             {/* Image skeleton */}
-            <View className="w-full aspect-[2/1] bg-muted dark:bg-secondary/40 animate-pulse" />
+            <View className={`${COVER_IMAGE_FRAME} bg-muted dark:bg-secondary/40 animate-pulse`} />
 
             {/* Content skeleton */}
             <View className="px-4 pt-3.5">

--- a/components/karriere/jobpostcard.tsx
+++ b/components/karriere/jobpostcard.tsx
@@ -1,8 +1,8 @@
 import { themeColors } from "@/lib/theme/colors";
-import { Image, View } from "react-native";
+import { View } from "react-native";
 import { Text } from "../ui/text";
 import { BriefcaseBusiness, MapPin, Building2 } from "lucide-react-native";
-import ImageMissing from '../ui/imageMissing';
+import CoverImage, { COVER_IMAGE_FRAME } from '../ui/coverImage';
 import { useColorScheme } from "@/lib/useColorScheme";
 
 export interface JobPostProps {
@@ -61,17 +61,7 @@ export default function JobPostCard(props: JobPostProps) {
     return (
         <View className="pb-7">
             {/* Full-width image */}
-            <View className="w-full aspect-[2/1] overflow-hidden">
-                {props.image ? (
-                    <Image
-                        source={{ uri: props.image }}
-                        className="w-full h-full"
-                        resizeMode="cover"
-                    />
-                ) : (
-                    <ImageMissing />
-                )}
-            </View>
+            <CoverImage uri={props.image} />
 
             {/* Content */}
             <View className="px-4 pt-3.5">
@@ -118,7 +108,7 @@ export function JobPostCardSkeleton() {
     return (
         <View className="pb-7">
             {/* Image skeleton */}
-            <View className="w-full aspect-[2/1] bg-muted dark:bg-secondary/40 animate-pulse" />
+            <View className={`${COVER_IMAGE_FRAME} bg-muted dark:bg-secondary/40 animate-pulse`} />
 
             {/* Content skeleton */}
             <View className="px-4 pt-3.5">

--- a/components/ui/coverImage.tsx
+++ b/components/ui/coverImage.tsx
@@ -1,0 +1,44 @@
+import { Image, View } from "react-native";
+
+import { coverImageUrl } from "@/lib/images";
+import { cn } from "@/lib/utils";
+import ImageMissing from "./imageMissing";
+
+/**
+ * Rammen forsidebilder vises i, i takt med `cover-wide` i Photons
+ * `IMAGE_PRESETS`.
+ *
+ * 21/9 er ikke et vilkårlig valg: den gamle opplastingsdialogen beskar alle
+ * arrangement-, nyhets- og stillingsbilder til 21:9 før lagring, så hele det
+ * migrerte arkivet er fysisk 1000×429, 1500×642 og så videre. Vises de i en
+ * annen ramme, kastes piksler bort for ingenting — og motivet blir beskåret.
+ */
+export const COVER_IMAGE_FRAME = "w-full aspect-[21/9]";
+
+export default function CoverImage({
+    uri,
+    className,
+}: {
+    uri?: string | null;
+    className?: string;
+}) {
+    return (
+        <View
+            className={cn(
+                COVER_IMAGE_FRAME,
+                "overflow-hidden bg-muted dark:bg-secondary/30",
+                className,
+            )}
+        >
+            {uri ? (
+                <Image
+                    source={{ uri: coverImageUrl(uri) }}
+                    className="w-full h-full"
+                    resizeMode="cover"
+                />
+            ) : (
+                <ImageMissing />
+            )}
+        </View>
+    );
+}

--- a/components/ui/userCard.tsx
+++ b/components/ui/userCard.tsx
@@ -1,4 +1,5 @@
 import { User } from "@/actions/types";
+import { avatarImageUrl } from "@/lib/images";
 import { Image, View } from "react-native";
 import { Text } from "./text";
 
@@ -8,7 +9,11 @@ export default function UserCard({ user }: { user: User }) {
     return (
         <View className="flex-row items-center px-4 py-3">
             {user.image ? (
-                <Image className="w-10 h-10 rounded-full" source={{ uri: user.image }} />
+                <Image
+                    className="w-10 h-10 rounded-full"
+                    source={{ uri: avatarImageUrl(user.image) }}
+                    resizeMode="cover"
+                />
             ) : (
                 <View className="w-10 h-10 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
                     <Text className="text-sm font-bold text-primary">

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -1,0 +1,70 @@
+/**
+ * Bilde-URLer mot Photons `/api/assets`.
+ *
+ * Speiler `apps/kvark/src/lib/assets.ts` i Photon: originalene er det som ble
+ * lastet opp — det migrerte arkivet inneholder JPEG-er rett fra kamera — så et
+ * kort som rendres 400 px bredt skal aldri peke på en av dem. `?w=` gir samme
+ * bilde skalert (og WebP-omkodet) med bevart sideforhold.
+ *
+ * Nettsiden bruker `srcSet` og lar nettleseren velge bredde. React Native har
+ * ingen `srcSet`, så bredden velges her ut fra hvor bredt bildet faktisk
+ * rendres, ganget med skjermens pikselforhold.
+ */
+import { Dimensions, PixelRatio } from "react-native";
+
+/**
+ * Breddene `GET /api/assets/:key?w=` godtar. Må holdes i takt med
+ * `IMAGE_VARIANT_WIDTHS` i Photon-APIet — en bredde utenfor listen er en 400,
+ * ikke et stille fullstort bilde.
+ */
+export const ASSET_IMAGE_WIDTHS = [
+    160, 320, 480, 640, 960, 1280, 1920,
+] as const;
+
+export type AssetImageWidth = (typeof ASSET_IMAGE_WIDTHS)[number];
+
+const LARGEST_WIDTH = ASSET_IMAGE_WIDTHS[ASSET_IMAGE_WIDTHS.length - 1];
+
+/**
+ * Bare asset-URLer har varianter. Innebygde bilder under `@/assets` og alt en
+ * tredjepart hoster sendes videre urørt.
+ */
+function isAssetUrl(url: string): boolean {
+    return url.includes("/api/assets/");
+}
+
+/** Samme bilde i gitt bredde. */
+export function assetImageUrl(url: string, width: AssetImageWidth): string {
+    if (!isAssetUrl(url)) return url;
+
+    const separator = url.includes("?") ? "&" : "?";
+    return `${url}${separator}w=${width}`;
+}
+
+/**
+ * Minste tillatte variant som dekker `layoutWidth` i faktiske piksler. En
+ * mindre variant ville blitt oppskalert og sett uskarp ut på retina-skjermer.
+ */
+export function assetImageWidthFor(layoutWidth: number): AssetImageWidth {
+    const pixels = PixelRatio.getPixelSizeForLayoutSize(layoutWidth);
+    return ASSET_IMAGE_WIDTHS.find((width) => width >= pixels) ?? LARGEST_WIDTH;
+}
+
+/**
+ * Forsidebilde i full skjermbredde — kort og hero-bilder ligger kant til kant.
+ */
+export function coverImageUrl(url: string, layoutWidth?: number): string {
+    const width = layoutWidth ?? Dimensions.get("window").width;
+    return assetImageUrl(url, assetImageWidthFor(width));
+}
+
+/**
+ * Profilbilder og gruppelogoer rendres aldri over ~112 px, så én liten variant
+ * er nok — og det hindrer at en medlemsliste drar ned et dusin fullstore
+ * profilbilder.
+ */
+export function avatarImageUrl(url: string): string;
+export function avatarImageUrl(url: string | undefined): string | undefined;
+export function avatarImageUrl(url: string | undefined): string | undefined {
+    return url === undefined ? undefined : assetImageUrl(url, 160);
+}


### PR DESCRIPTION
## Hva

Forsidebilder (arrangementer og stillingsannonser) vises nå i **21:9**, både på kortene og øverst på detaljsidene. Før var det 2:1 på kortene og 16:9 på detaljsidene.

## Hvorfor

Fasiten er Photons `IMAGE_PRESETS` (`packages/ui/src/ui/image-preset.tsx`): `cover-wide` = 21:9 for arrangement-, nyhets- og stillingsbilder. Det er ikke et designvalg man kan overstyre — den gamle Kvark-opplasteren beskar disse bildene til 21:9 før lagring, så hele det migrerte arkivet er fysisk 1000×429, 1500×642 og så videre (bekreftet mot `/api/assets/...`). Rammene i appen beskar altså bort motiv uten å vinne noe.

## Endringer

- **Ny `lib/images.ts`** — speiler `apps/kvark/src/lib/assets.ts` i Photon. `?w=` gir skalerte WebP-varianter i stedet for originalen. Nettsiden lar nettleseren velge via `srcSet`; React Native har ingen `srcSet`, så bredden velges her ut fra hvor bredt bildet faktisk rendres ganget med pikselforholdet. `avatarImageUrl` henter én liten variant (160).
- **Ny `components/ui/coverImage.tsx`** — én 21:9-ramme med `cover`-fit og TIHLDE-fallbacken. `COVER_IMAGE_FRAME` er eksportert så skjelettene ikke kan drifte fra rammen.
- Tatt i bruk i `eventCard`, `jobpostcard`, arrangement-detalj og karriere-detalj.
- Profilbilder og gruppelogoer går gjennom `avatarImageUrl` med eksplisitt `resizeMode="cover"` (profil, botgrupper, brukervalg, `userCard`).

## Verifisert

- `tsc --noEmit`: nøyaktig samme 23 feil som før endringen — alle preexisterende (ruter, BottomSheet, implisitt `any`). Ingen nye.
- `expo lint`: 0 feil.
- Appen bygger og kjører i simulatoren.

**Ikke verifisert visuelt:** kortene ligger bak innlogging, og simulator-appen var koblet til en Metro-instans fra en annen worktree, så bundelen med endringene ble aldri servert. Verdt en rask titt fra en som er logget inn.

## Verdt å vite

- Prod svarer per nå med **originalbildet** på `?w=` — variantgenereringen faller tilbake, trolig fordi `sharp` ikke lastes i API-et. Parameteren er ufarlig og slår inn av seg selv når det fikses på Photon-siden.
- Fallbacken `tihlde-default.png` er 1400×800 og beskjæres litt i 21:9-rammen — samme behandling som Photons eget fallback (1280×731) får på nettsiden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)