### PR TITLE
fix: fungerende datovelger, mørk modus på bunnark, og filtre som faktisk filtrerer

### DIFF
--- a/actions/events/events.ts
+++ b/actions/events/events.ts
@@ -8,6 +8,10 @@ type PhotonEventList = { items: PhotonEvent[]; totalCount: number; nextPage: num
 /**
  * Arrangementslista. Åpne data, så den går uten token — men gjennom samme
  * base-URL som resten, slik at bare ett sted peker på API-et.
+ *
+ * Photon ignorerer ukjente query-parametre i stillhet, så et feilstavet filter
+ * ser ut til å virke mens det ikke gjør noe. Navnene her må stemme med
+ * `/api/event` i https://photon.tihlde.org/openapi.
  */
 export async function fetchEvents(params?: URLSearchParams): Promise<{ results: Event[]; next: string | null }> {
     const query = params ? `?${params}` : "";
@@ -22,6 +26,59 @@ export async function fetchEvents(params?: URLSearchParams): Promise<{ results: 
         results: data.items.map((event) => toEvent(event)),
         next: data.nextPage !== null ? String(data.nextPage) : null,
     };
+}
+
+/** Det Photon gir oss om et favorittmerket arrangement. */
+type PhotonFavoriteEvent = {
+    eventId: string;
+    title: string;
+    slug: string;
+    startTime: string;
+    endTime: string;
+    createdAt: string;
+};
+
+/**
+ * Favorittmerkede arrangementer.
+ *
+ * Photon har ingen favoritt-parameter på arrangementslista, bare et eget
+ * endepunkt — og det svarer med en tynn form uten bilde, arrangør eller sted,
+ * så hvert arrangement må hentes for seg for å kunne vises som kort.
+ *
+ * Lista er ikke paginert hos Photon, og favoritter er få nok til at alt
+ * hentes i én omgang. Søk og tidligere/kommende filtreres derfor her.
+ */
+export async function fetchFavoriteEvents(options: {
+    search?: string;
+    expired: boolean;
+}): Promise<{ results: Event[]; next: string | null }> {
+    const favorites = await apiJson<PhotonFavoriteEvent[]>("/event/favorite");
+
+    const now = Date.now();
+    const search = options.search?.trim().toLowerCase();
+
+    const wanted = favorites.filter((favorite) => {
+        const isOver = new Date(favorite.endTime).getTime() < now;
+        if (isOver !== options.expired) return false;
+        return !search || favorite.title.toLowerCase().includes(search);
+    });
+
+    // Ett oppslag per favoritt. Faller et enkelt bort — slettet arrangement,
+    // eller et man ikke lenger har tilgang til — utelates det i stedet for at
+    // hele lista feiler.
+    const events = await Promise.all(
+        wanted.map((favorite) => fetchEvent(favorite.eventId).catch(() => null)),
+    );
+
+    const results = events.filter((event): event is Event => event !== null);
+    results.sort((a, b) => {
+        const left = new Date(a.start_date).getTime();
+        const right = new Date(b.start_date).getTime();
+        // Kommende: det som skjer først øverst. Tidligere: sist avholdte først.
+        return options.expired ? right - left : left - right;
+    });
+
+    return { results, next: null };
 }
 
 export async function fetchEvent(eventId: string): Promise<Event> {

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -395,7 +395,7 @@ export default function ArrangementSide() {
                     </View>
 
                     <InteropBottomSheetModal ref={bottomSheetModalRef}
-                        backgroundStyleClassName="bg-primary-foreground rounded-3xl"
+                        backgroundStyleClassName="bg-popover rounded-3xl"
                         snapPoints={["75%"]}
                         index={0}
                         enableDynamicSizing={false}
@@ -411,7 +411,7 @@ export default function ArrangementSide() {
                     </InteropBottomSheetModal>
 
                     <InteropBottomSheetModal ref={unregisterSheetRef}
-                        backgroundStyleClassName="bg-primary-foreground rounded-3xl"
+                        backgroundStyleClassName="bg-popover rounded-3xl"
                         enableDynamicSizing
                         backdropComponent={(props) => (
                             <BottomSheetBackdrop
@@ -479,7 +479,7 @@ function UnregisterDrawer({
 
     if (status === 'loading') {
         return (
-            <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-8">
+            <BottomSheetView className="bg-popover px-6 pb-10 pt-8">
                 <View className="items-center py-4">
                     <ActivityIndicator size="large" />
                     <Text className="text-base text-muted-foreground mt-4">
@@ -492,7 +492,7 @@ function UnregisterDrawer({
 
     if (status === 'success') {
         return (
-            <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-6">
+            <BottomSheetView className="bg-popover px-6 pb-10 pt-6">
                 <View className="items-center py-4">
                     <View className="w-14 h-14 rounded-full bg-primary/10 dark:bg-primary/20 items-center justify-center mb-4">
                         <CircleCheck size={26} color={themeColors(isDarkColorScheme).primary} />
@@ -509,7 +509,7 @@ function UnregisterDrawer({
     }
 
     return (
-        <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-6">
+        <BottomSheetView className="bg-popover px-6 pb-10 pt-6">
             <View className="items-center mb-4">
                 <View className="w-14 h-14 rounded-full bg-destructive/10 dark:bg-destructive/20 items-center justify-center mb-4">
                     <TriangleAlert size={26} color={themeColors(isDarkColorScheme).destructive} />
@@ -566,7 +566,7 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
 
     if (isError) {
         return (
-            <BottomSheetView className="bg-primary-foreground flex-1">
+            <BottomSheetView className="bg-popover flex-1">
                 <View className="px-4 pt-4 pb-3">
                     <Text className="text-lg font-bold text-center text-foreground">Deltagerliste</Text>
                 </View>
@@ -580,7 +580,7 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
 
     if (isPending) {
         return (
-            <BottomSheetView className="bg-primary-foreground flex-1">
+            <BottomSheetView className="bg-popover flex-1">
                 <View className="px-4 pt-4 pb-3">
                     <Text className="text-lg font-bold text-center text-foreground">Deltagerliste</Text>
                 </View>
@@ -598,7 +598,7 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
 
     return (
         <BottomSheetFlatList
-            className="bg-primary-foreground"
+            className="bg-popover"
             data={participants}
             stickyHeaderIndices={[0]}
             renderItem={({ item: registration }) => (
@@ -613,7 +613,7 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
                 fetchNextPage();
             }}
             ListHeaderComponent={
-                <View className="bg-primary-foreground">
+                <View className="bg-popover">
                     <View className="px-4 pt-4 pb-3">
                         <Text className="text-lg font-bold text-center text-foreground">Deltagerliste</Text>
                         <Text className="text-sm text-muted-foreground text-center mt-0.5">

--- a/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
@@ -154,7 +154,7 @@ function CameraRegistration({ cameraDisabled = false }: { cameraDisabled?: boole
             }
             <InteropBottomSheetModal
                 ref={bottomSheetModalRef}
-                backgroundStyleClassName="bg-primary-foreground rounded-3xl"
+                backgroundStyleClassName="bg-popover rounded-3xl"
                 enableDynamicSizing
                 backdropComponent={(props) => (
                     <BottomSheetBackdrop
@@ -165,7 +165,7 @@ function CameraRegistration({ cameraDisabled = false }: { cameraDisabled?: boole
                     />
                 )}
             >
-                <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-6">
+                <BottomSheetView className="bg-popover px-6 pb-10 pt-6">
                     {registrationSuccess ? (
                         <View className="items-center py-4">
                             <View className="w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/30 items-center justify-center mb-4">

--- a/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId]/event-register.tsx
@@ -276,6 +276,8 @@ function ManualRegistration() {
                             onChangeText={setSearchText}
                             autoCapitalize="none"
                             autoCorrect={false}
+                            inputMode="search"
+                            returnKeyType="search"
                             style={{ fontFamily: "Inter", fontSize: 16, lineHeight: 20, paddingTop: 0, paddingBottom: 0 }}
                         />
                         {searchText.length > 0 && (

--- a/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
@@ -117,6 +117,8 @@ export default function UserSelection() {
                                     onChangeText={setSearchText}
                                     autoCapitalize="none"
                                     autoCorrect={false}
+                                    inputMode="search"
+                                    returnKeyType="search"
                                     style={{
                                         fontFamily: "Inter",
                                         fontSize: 16,

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -150,6 +150,8 @@ export default function Arrangementer() {
                                         onChangeText={setSearchText}
                                         autoCapitalize="none"
                                         autoCorrect={false}
+                                        inputMode="search"
+                                        returnKeyType="search"
                                         style={{ fontFamily: "Inter", fontSize: 16, lineHeight: 20, paddingTop: 0, paddingBottom: 0 }}
                                     />
                                     {searchText.length > 0 && (

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -5,7 +5,7 @@ import { router, Stack } from "expo-router";
 import { ActivityIndicator, FlatList, Pressable, TextInput, View } from "react-native";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import PageWrapper from "@/components/ui/pagewrapper";
-import { fetchEvents as fetchEventList } from "@/actions/events/events";
+import { fetchEvents as fetchEventList, fetchFavoriteEvents } from "@/actions/events/events";
 import type { Event } from "@/actions/types";
 import useRefresh from "@/lib/useRefresh";
 import useDebounce from "@/lib/useDebounce";
@@ -63,8 +63,19 @@ export default function Arrangementer() {
         // lengst fram i tid øverst. Med false kommer det som skjer først
         // øverst, og med true de sist avholdte.
         queryParams.set('expired', filters.expired ? 'true' : 'false');
-        if (filters.openForSignUp) queryParams.set('openForSignUp', 'true');
-        if (filters.userFavorite) queryParams.set('userFavorite', 'true');
+        // Parameteren heter `openSignUp` i Photon. Den het `openForSignUp` her,
+        // og siden ukjente parametre blir ignorert i stillhet så filteret ut
+        // til å virke mens det ikke gjorde noe.
+        if (filters.openForSignUp) queryParams.set('openSignUp', 'true');
+
+        // Favoritter er ikke et filter på lista i Photon — de har sitt eget
+        // endepunkt — så de hentes for seg.
+        if (filters.userFavorite) {
+            return fetchFavoriteEvents({
+                search: debouncedSearch,
+                expired: filters.expired,
+            });
+        }
 
         return fetchEventList(queryParams);
     }, [debouncedSearch, filters]);

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -276,7 +276,7 @@ export default function Arrangementer() {
 
                 {/* Filter drawer */}
                 <InteropBottomSheetModal ref={filterSheetRef}
-                    backgroundStyleClassName="bg-primary-foreground rounded-3xl"
+                    backgroundStyleClassName="bg-popover rounded-3xl"
                     enableDynamicSizing
                     backdropComponent={(props) => (
                         <BottomSheetBackdrop
@@ -286,7 +286,7 @@ export default function Arrangementer() {
                             {...props}
                         />
                     )} >
-                    <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-4">
+                    <BottomSheetView className="bg-popover px-6 pb-10 pt-4">
                         {/* Header */}
                         <View className="flex-row items-center justify-between mb-5">
                             <View className="flex-row items-center">

--- a/app/(app)/(tabs)/profil/index.tsx
+++ b/app/(app)/(tabs)/profil/index.tsx
@@ -188,7 +188,7 @@ export default function Profil() {
                     </View>
 
                     <InteropBottomSheetModal ref={logoutSheetRef}
-                        backgroundStyleClassName="bg-primary-foreground rounded-3xl"
+                        backgroundStyleClassName="bg-popover rounded-3xl"
                         enableDynamicSizing
                         backdropComponent={(props) => (
                             <BottomSheetBackdrop
@@ -198,7 +198,7 @@ export default function Profil() {
                                 {...props}
                             />
                         )} >
-                        <BottomSheetView className="bg-primary-foreground px-6 pb-10 pt-6">
+                        <BottomSheetView className="bg-popover px-6 pb-10 pt-6">
                             <View className="items-center mb-4">
                                 <View className="w-14 h-14 rounded-full bg-destructive/10 dark:bg-destructive/20 items-center justify-center mb-4">
                                     <TriangleAlert size={26} color={themeColors(isDarkColorScheme).destructive} />

--- a/app/(app)/(tabs)/utlegg/nytt.tsx
+++ b/app/(app)/(tabs)/utlegg/nytt.tsx
@@ -6,6 +6,7 @@ import {
     Platform,
     Pressable,
     ScrollView,
+    StyleSheet,
     TextInput,
     View,
 } from "react-native";
@@ -35,7 +36,7 @@ import PageWrapper from "@/components/ui/pagewrapper";
 import { Text } from "@/components/ui/text";
 import { SectionHeader } from "@/components/ui/section-header";
 import { useColorScheme } from "@/lib/useColorScheme";
-import { themeColors } from "@/lib/theme/colors";
+import { themeColors, type ThemeColors } from "@/lib/theme/colors";
 import type { BudgetType } from "@/actions/types";
 
 /** En valgt kvittering. `key` settes først når fila er lastet opp. */
@@ -47,6 +48,9 @@ type Receipt = {
 };
 
 const ACCOUNT_PATTERN = /^\d{4}\.\d{2}\.\d{5}$/;
+// Bevisst romslig: e-post skal avvises bare når den åpenbart ikke kan
+// leveres til. Photon eier den endelige valideringen.
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_ATTACHMENTS = 10;
 
 /** Photon vil ha `YYYY-MM-DD`; `toISOString` ville gitt gårsdagen før kl. 01 om vinteren. */
@@ -69,6 +73,30 @@ function formatDateLabel(iso: string): string {
         month: "long",
         year: "numeric",
     });
+}
+
+/** Legger `top` med gitt alpha over `bottom` og gir en ugjennomsiktig hex. */
+function blend(top: string, bottom: string, alpha: number): string {
+    const channels = (hex: string) =>
+        [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+    const [tr, tg, tb] = channels(top);
+    const [br, bg, bb] = channels(bottom);
+    const mix = (t: number, b: number) =>
+        Math.round(t * alpha + b * (1 - alpha))
+            .toString(16)
+            .padStart(2, "0");
+    return `#${mix(tr, br)}${mix(tg, bg)}${mix(tb, bb)}`;
+}
+
+/**
+ * Feltbakgrunnen som en ugjennomsiktig farge.
+ *
+ * Feltene bruker ellers `bg-secondary/30`, men datofeltet må dekke over
+ * pillen til den native datovelgeren — og en halvgjennomsiktig bakgrunn ville
+ * latt den skinne gjennom. Lys modus bruker `bg-gray-100`, som allerede er tett.
+ */
+function solidFieldColor(colors: ThemeColors, isDark: boolean): string {
+    return isDark ? blend(colors.secondary, colors.background, 0.3) : "#f3f4f6";
 }
 
 /** Formaterer kontonummer til xxxx.xx.xxxxx mens det skrives. */
@@ -175,7 +203,8 @@ export default function NyttUtlegg() {
     /** Første feilmelding, eller null når skjemaet kan sendes. */
     const validate = (): string | null => {
         if (!contactName.trim()) return "Fyll inn navn.";
-        if (!contactEmail.trim().includes("@")) return "Fyll inn en gyldig e-post.";
+        if (!EMAIL_PATTERN.test(contactEmail.trim()))
+            return "Fyll inn en gyldig e-post.";
         const parsedAmount = Number(amount);
         if (!Number.isInteger(parsedAmount) || parsedAmount <= 0)
             return "Beløpet må være et helt antall kroner over 0.";
@@ -353,53 +382,98 @@ export default function NyttUtlegg() {
 
                     <SectionHeader title="Utlegget" />
                     <View className="gap-y-3 mb-6">
-                        <View>
-                            <Text className="text-sm text-muted-foreground mb-1.5">Beløp (kr)</Text>
-                            <TextInput
-                                value={amount}
-                                onChangeText={(text) => setAmount(text.replace(/\D/g, ""))}
-                                keyboardType="number-pad"
-                                placeholder="0"
-                                placeholderTextColor={colors.mutedForeground}
-                                className={inputClass}
-                            />
-                        </View>
-
-                        <View>
-                            <Text className="text-sm text-muted-foreground mb-1.5">
-                                Dato for kjøpet
-                            </Text>
-                            <Pressable
-                                onPress={() => {
-                                    setOpenPicker(null);
-                                    setIsDatePickerOpen((open) => !open);
-                                }}
-                                className="flex-row items-center justify-between h-12 rounded-xl bg-gray-100 dark:bg-secondary/30 px-4 active:opacity-70"
-                            >
-                                <Text className="text-base text-foreground">
-                                    {formatDateLabel(expenseDate)}
+                        {/* Beløp og dato er begge korte verdier, så de deler rad. */}
+                        <View className="flex-row gap-x-3">
+                            <View className="flex-1">
+                                <Text className="text-sm text-muted-foreground mb-1.5">
+                                    Beløp (kr)
                                 </Text>
-                                <Calendar size={18} color={colors.mutedForeground} />
-                            </Pressable>
-
-                            {isDatePickerOpen && (
-                                <DateTimePicker
-                                    value={fromIsoDate(expenseDate)}
-                                    mode="date"
-                                    // iOS viser hjulet i skjemaet; Android åpner sin egen dialog.
-                                    display={Platform.OS === "ios" ? "spinner" : "default"}
-                                    locale="nb-NO"
-                                    maximumDate={new Date()}
-                                    themeVariant={isDarkColorScheme ? "dark" : "light"}
-                                    onChange={(event, date) => {
-                                        // Android lukker seg selv; iOS-hjulet blir stående
-                                        // til man trykker på feltet igjen.
-                                        if (Platform.OS !== "ios") setIsDatePickerOpen(false);
-                                        if (event.type === "set" && date)
-                                            setExpenseDate(toIsoDate(date));
-                                    }}
+                                <TextInput
+                                    value={amount}
+                                    onChangeText={(text) => setAmount(text.replace(/\D/g, ""))}
+                                    keyboardType="number-pad"
+                                    // 1 000 000 er taket, så sju siffer er alt som trengs.
+                                    maxLength={7}
+                                    placeholder="0"
+                                    placeholderTextColor={colors.mutedForeground}
+                                    className={inputClass}
                                 />
-                            )}
+                            </View>
+
+                            <View className="flex-1">
+                                <Text className="text-sm text-muted-foreground mb-1.5">
+                                    Dato for kjøpet
+                                </Text>
+                                {Platform.OS === "ios" ? (
+                                    // Kontrollen ligger under, og raden tegnes oppå som et
+                                    // ugjennomsiktig lokk: pillen dens lar seg ikke style
+                                    // bort, så den skjules i stedet. Lokket tar ikke imot
+                                    // trykk, så de går rett gjennom til kontrollen.
+                                    <View className="h-12 justify-center overflow-hidden rounded-xl">
+                                        <DateTimePicker
+                                            value={fromIsoDate(expenseDate)}
+                                            mode="date"
+                                            display="compact"
+                                            locale="nb-NO"
+                                            maximumDate={new Date()}
+                                            themeVariant={isDarkColorScheme ? "dark" : "light"}
+                                            onChange={(_event, date) => {
+                                                if (date) setExpenseDate(toIsoDate(date));
+                                            }}
+                                        />
+                                        <View
+                                            pointerEvents="none"
+                                            style={{
+                                                ...StyleSheet.absoluteFillObject,
+                                                backgroundColor: solidFieldColor(
+                                                    colors,
+                                                    isDarkColorScheme,
+                                                ),
+                                            }}
+                                            className="flex-row items-center justify-between rounded-xl px-3"
+                                        >
+                                            <Text
+                                                className="text-base text-foreground"
+                                                numberOfLines={1}
+                                            >
+                                                {formatDateLabel(expenseDate)}
+                                            </Text>
+                                            <Calendar
+                                                size={18}
+                                                color={colors.mutedForeground}
+                                            />
+                                        </View>
+                                    </View>
+                                ) : (
+                                    <Pressable
+                                        onPress={() => {
+                                            setOpenPicker(null);
+                                            setIsDatePickerOpen(true);
+                                        }}
+                                        className="flex-row items-center justify-between h-12 rounded-xl bg-gray-100 dark:bg-secondary/30 px-3 active:opacity-70"
+                                    >
+                                        <Text className="text-base text-foreground" numberOfLines={1}>
+                                            {formatDateLabel(expenseDate)}
+                                        </Text>
+                                        <Calendar size={18} color={colors.mutedForeground} />
+                                    </Pressable>
+                                )}
+
+                                {isDatePickerOpen && Platform.OS !== "ios" && (
+                                    <DateTimePicker
+                                        value={fromIsoDate(expenseDate)}
+                                        mode="date"
+                                        display="default"
+                                        maximumDate={new Date()}
+                                        onChange={(event, date) => {
+                                            // Dialogen lukker seg selv etter valg.
+                                            setIsDatePickerOpen(false);
+                                            if (event.type === "set" && date)
+                                                setExpenseDate(toIsoDate(date));
+                                        }}
+                                    />
+                                )}
+                            </View>
                         </View>
 
                         <Select
@@ -474,10 +548,19 @@ export default function NyttUtlegg() {
                                     setAccountNumber(formatAccountNumber(text))
                                 }
                                 keyboardType="number-pad"
+                                autoCorrect={false}
                                 placeholder="1234.56.78901"
                                 placeholderTextColor={colors.mutedForeground}
                                 className={inputClass}
                             />
+                            {/* Sier fra mens man skriver i stedet for å vente til
+                                man trykker «Send inn utlegg». */}
+                            {accountNumber.length > 0 &&
+                                !ACCOUNT_PATTERN.test(accountNumber) && (
+                                    <Text className="text-xs text-muted-foreground mt-1.5">
+                                        {`Mangler ${11 - accountNumber.replace(/\D/g, "").length} siffer.`}
+                                    </Text>
+                                )}
                         </View>
 
                         <View>
@@ -486,6 +569,9 @@ export default function NyttUtlegg() {
                                 value={contactName}
                                 onChangeText={setContactName}
                                 maxLength={200}
+                                autoCapitalize="words"
+                                autoComplete="name"
+                                textContentType="name"
                                 placeholder="Ditt navn"
                                 placeholderTextColor={colors.mutedForeground}
                                 className={inputClass}
@@ -499,6 +585,10 @@ export default function NyttUtlegg() {
                                 onChangeText={setContactEmail}
                                 keyboardType="email-address"
                                 autoCapitalize="none"
+                                // Autokorrektur på en e-postadresse gjør mer skade enn nytte.
+                                autoCorrect={false}
+                                autoComplete="email"
+                                textContentType="emailAddress"
                                 placeholder="din@epost.no"
                                 placeholderTextColor={colors.mutedForeground}
                                 className={inputClass}


### PR DESCRIPTION
Tre feil som hadde det til felles at de så ut til å virke. Alle er funnet ved å kjøre appen i simulator eller måle mot Photon, ikke ved lesing.

## 1. Datovelgeren for utlegg var død

[#127](https://github.com/TIHLDE/Native/pull/127) byttet fritekstfeltet mot et inline `spinner`-hjul. Det kollapser til null høyde under den nye arkitekturen i SDK 54, så feltet var ikke mulig å åpne. Ingen JS-feil — komponenten monterte, den tegnet bare ingenting.

iOS bruker nå Apples kompakte kontroll, som åpner kalenderen sin selv. Pillen den tegner rundt datoen lar seg ikke style bort, så den synlige raden legges oppå som et lokk med `pointerEvents="none"`: pillen skjules, og trykk går rett gjennom. Lokket må være ugjennomsiktig, og fargen regnes ut fra temaet med en `blend()`-hjelper framfor en gjettet hex, så feltet ser likt ut som de andre. Android beholder sin dialog.

Beløp og dato deler nå rad. Begge er korte verdier, feltene blir like høye, og skjemaet blir en rad kortere.

## 2. Bunnark var hvite i mørk modus

Arkene brukte `bg-primary-foreground` som flate. Den er `#fafafa` i lys og `#ffffff` i mørk — nesten hvit i begge — fordi den er ment som tekstfarge oppå primærknapper. I mørk modus ble arket hvitt mens `text-foreground` ble hvit tekst, så overskriftene forsvant. Lys modus så riktig ut ved en tilfeldighet.

Bruker `bg-popover` i stedet, som er den mest hevede av temaets tre flateverdier. Feilen lå i alle fem arkene, så alle femten stedene er rettet.

## 3. To av tre arrangementsfiltre gjorde ingenting

Photon ignorerer ukjente query-parametre i stillhet, så filtrene så ut til å virke: toggelen slo på, chipen dukket opp, lista ble hentet på nytt — og svarte med alt.

Målt mot `/api/event`:

| Forespørsel | totalCount |
|---|---|
| ingen filtre | 26 |
| `userFavorite=true` | 26 |
| `openForSignUp=true` | 26 |
| en parameter jeg fant på | 26 |
| `expired=true` (kontroll) | 1202 |
| **`openSignUp=true`** (riktig navn) | **0** |

Fasiten ligger i https://photon.tihlde.org/openapi. `/api/event` tar `pageSize`, `page`, `search`, `category`, `expired`, `openSignUp`, `organizerGroupSlug` og `ordering`.

- **Påmelding** het `openSignUp`, ikke `openForSignUp`. Ren navnefeil.
- **Favoritter** finnes ikke som listefilter i det hele tatt. Token var nødvendig, men ikke nok — jeg målte 26 også autentisert. Det eneste som finnes er `GET /api/event/favorite`, som gir en tynn form uten bilde, arrangør eller sted, så hver favoritt slås opp mot `/event/{id}`. Lista er ikke paginert og favoritter er få, så alt hentes i én omgang og søk og tidligere/kommende filtreres lokalt.

## Opprydding i skjemafelt

Felt som lot enheten gjøre feil jobb:

- `Navn` fikk `autoCapitalize="words"` og name-hint; `E-post` fikk `autoCorrect={false}` og emailAddress-hint. Autokorrektur på en e-postadresse gjør mer skade enn nytte.
- De tre søkefeltene fikk `inputMode` og `returnKeyType="search"`. `clearButtonMode` er utelatt med vilje — alle tre har allerede en egen X som deler plass med en spinner.
- E-postvalideringen var `.includes("@")`, som slapp gjennom `"@"`. Beløp fikk `maxLength`, og kontonummer sier nå fra mens man skriver hvor mange siffer som mangler.

## Testing

Kjørt i simulator på iPhone 17 Pro gjennom hele arbeidet.

- **Datovelger:** åpner kalenderen, dato velges, feltet viser riktig norsk dato. Bekreftet av en faktisk fingertrykk — mine syntetiske trykk når ikke `Pressable`-er i denne appen, noe som kostet et par feilslutninger underveis.
- **Mørk modus:** arket har flate i begge temaer. Krevde `expo start --clear` — `bg-popover` var ny i kodebasen, så NativeWind hadde aldri generert klassen og den ble til ingenting.
- **Favorittfilteret:** verifisert ende til ende ved å midlertidig sette filteret på som standard. Lista ga ett kort, «Obs! Jeg kom feil!», mot 26 før. Testoppsettet er fjernet igjen.
- `tsc --noEmit` gir 62 feil både på ren `main` og med denne grenen — identisk, så ingen er innført. Alle er preeksisterende. `expo lint`: 0 feil, 5 preeksisterende advarsler.

## Verdt å se på senere

Ikke rørt her, men funnet underveis:

- `lib/timeformat.ts` er død kode med to reelle feil: minutter uten nullpadding (`14:5`) og feil ukedagsnavn (`getDay()` er 0 = søndag, men arrayet starter på «Man»). Ingenting importerer den.
- `components/ui/input.tsx` og `components/ui/floating-label-input.tsx` er også ubrukte.
- Trefflaten på datofeltet er bare der kontrollen ligger under lokket, ikke helt ut til ikonet. Feltet er kort nok til at det knapt merkes, men kan strammes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)