### PR TITLE
chore: bump versjon til 3.2.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TIHLDE",
     "slug": "Native",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "tihlde",


### PR DESCRIPTION
Samler endringene fra [#129](https://github.com/TIHLDE/Native/pull/129) og [#130](https://github.com/TIHLDE/Native/pull/130) i en ny versjon:

- fungerende datovelger for utlegg
- bunnark fikk flate i mørk modus
- favoritt- og påmeldingsfilteret filtrerer faktisk
- 202 linjer død kode fjernet

Bare `version` settes her. Byggnummeret styres av EAS gjennom `autoIncrement` med `appVersionSource: "remote"`, og står nå på 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)