### PR TITLE
feat: ny profilside med innstillinger, allergier og varselvalg

### DIFF
--- a/actions/photon.ts
+++ b/actions/photon.ts
@@ -7,12 +7,14 @@
  * derfor her, i ett lag, og skjermene er urørt.
  */
 import type {
+    Allergy,
     Event,
     GroupUser,
     Law,
     Membership,
     Notification,
     User,
+    UserSettings,
 } from "@/actions/types";
 
 export type PhotonUser = {
@@ -48,6 +50,46 @@ export const toUser = (user: PhotonUser | null | undefined): User =>
         studyyear: { group: { name: String(user?.studyStartYear ?? ""), slug: "" } },
         unanswered_evaluations_count: 0,
     }) as unknown as User;
+
+export type PhotonUserSettings = {
+    gender?: "male" | "female" | "other";
+    allowsPhotosByDefault: boolean;
+    acceptsEventRules: boolean;
+    receiveMailCommunication: boolean;
+    publicEventRegistrations?: boolean;
+    allergies?: string[];
+    bioDescription?: string;
+    githubUrl?: string;
+    linkedinUrl?: string;
+    imageUrl?: string;
+    isOnboarded?: boolean;
+};
+
+/**
+ * `publicEventRegistrations` og `allergies` kom til etter at feltene ble tatt i
+ * bruk, og er valgfrie i svaret. Standardene her er Photons egne: å stå
+ * oppført med navn er slik påmeldinger alltid har virket, og ingen allergier
+ * er en tom liste — ikke «ukjent».
+ */
+export const toUserSettings = (settings: PhotonUserSettings): UserSettings => ({
+    acceptsEventRules: settings.acceptsEventRules,
+    allowsPhotosByDefault: settings.allowsPhotosByDefault,
+    publicEventRegistrations: settings.publicEventRegistrations ?? true,
+    receiveMailCommunication: settings.receiveMailCommunication,
+    allergies: settings.allergies ?? [],
+});
+
+export type PhotonAllergy = {
+    slug: string;
+    label: string;
+    description?: string | null;
+};
+
+export const toAllergy = (allergy: PhotonAllergy): Allergy => ({
+    slug: allergy.slug,
+    label: allergy.label,
+    description: allergy.description ?? null,
+});
 
 export const toGroupUser = (user: PhotonUser | null | undefined): GroupUser => ({
     ...splitName(user?.name),

--- a/actions/types/index.ts
+++ b/actions/types/index.ts
@@ -9,3 +9,4 @@ export * from "./payment";
 export * from "./fine";
 export * from "./application";
 export * from "./notification";
+export * from "./settings";

--- a/actions/types/settings.ts
+++ b/actions/types/settings.ts
@@ -1,0 +1,36 @@
+/**
+ * Brukerinnstillingene Photon holder på `/user/me/settings`.
+ *
+ * `isOnboarded` er med i svaret fra API-et, men ikke her: appen har ingen
+ * onboarding-flyt å sende noen til, så flagget ville bare vært et felt ingen
+ * leser. Alt annet er noe innstillingsskjermen faktisk viser.
+ */
+export type UserSettings = {
+    /** Kreves for å melde seg på arrangementer. Photon avviser påmelding uten. */
+    acceptsEventRules: boolean;
+    /** Bildesamtykke: om bilder av deg fra arrangementer kan publiseres. */
+    allowsPhotosByDefault: boolean;
+    /** Om navnet ditt vises i deltakerlister. */
+    publicEventRegistrations: boolean;
+    /** Om TIHLDE kan sende deg e-post. */
+    receiveMailCommunication: boolean;
+    /** Slugene fra allergikatalogen, ikke fritekst. */
+    allergies: string[];
+};
+
+/** En rad i allergikatalogen — `/user/allergy`. */
+export type Allergy = {
+    slug: string;
+    label: string;
+    description: string | null;
+};
+
+/**
+ * Hvor varsler skal komme.
+ *
+ * Photon har ingen samlet innstilling for dette: e-post er
+ * `receiveMailCommunication` på brukerinnstillingene, mens push er om
+ * telefonen er meldt på i `/notification/device`. Valget her er de to
+ * kombinert, sånn at brukeren forholder seg til ett spørsmål.
+ */
+export type NotificationChannel = "none" | "email" | "push" | "both";

--- a/actions/users/settings.ts
+++ b/actions/users/settings.ts
@@ -1,0 +1,85 @@
+import { API_URL } from "@/actions/constant";
+import {
+    PhotonAllergy,
+    PhotonUserSettings,
+    toAllergy,
+    toUserSettings,
+} from "@/actions/photon";
+import type { Allergy, UserSettings } from "@/actions/types";
+import { apiFetch, apiJson } from "@/lib/api/client";
+
+/**
+ * Innstillingene en bruker uten innstillingsrad har.
+ *
+ * Photon oppretter ikke raden ved registrering — den kommer først når noen
+ * fullfører onboarding på nettsiden eller endrer én innstilling. Fram til da
+ * svarer `/user/me/settings` 404, og det betyr «ingen har svart», ikke «feil».
+ * Verdiene her er de samme Photon selv legger til grunn: bildesamtykke og
+ * offentlig påmelding er på, arrangementsreglene er ikke godkjent.
+ */
+export const DEFAULT_USER_SETTINGS: UserSettings = {
+    acceptsEventRules: false,
+    allowsPhotosByDefault: true,
+    publicEventRegistrations: true,
+    receiveMailCommunication: true,
+    allergies: [],
+};
+
+export const settingsKeys = {
+    mine: ["users", "me", "settings"],
+    allergies: ["allergies"],
+};
+
+export async function mySettings(): Promise<UserSettings> {
+    const response = await apiFetch("/user/me/settings");
+
+    // 404 er ikke en feil her — se DEFAULT_USER_SETTINGS.
+    if (response.status === 404) return DEFAULT_USER_SETTINGS;
+
+    if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+            | { message?: string }
+            | null;
+        throw new Error(
+            body?.message ?? `Kunne ikke hente innstillingene (${response.status})`,
+        );
+    }
+
+    return toUserSettings((await response.json()) as PhotonUserSettings);
+}
+
+/**
+ * Oppdaterer bare feltene som sendes med. Photon oppretter innstillingsraden
+ * hvis den mangler, så en bruker som aldri har vært innom onboarding kan
+ * fortsatt godta arrangementsreglene herfra.
+ *
+ * Svaret er hele innstillingssettet etter endringen, så skjermen slipper et
+ * ekstra kall for å vise resultatet.
+ */
+export async function updateMySettings(
+    updates: Partial<UserSettings>,
+): Promise<UserSettings> {
+    const updated = await apiJson<PhotonUserSettings>("/user/me/settings", {
+        method: "PATCH",
+        body: JSON.stringify(updates),
+    });
+
+    return toUserSettings(updated);
+}
+
+/**
+ * Allergikatalogen. Åpne data, som arrangementslista, så den går uten token.
+ *
+ * Allergier lagres som sluger mot denne tabellen — fritekst finnes ikke, og et
+ * navn som ikke står her kan ikke lagres.
+ */
+export async function fetchAllergies(): Promise<Allergy[]> {
+    const response = await fetch(`${API_URL}/user/allergy`);
+
+    if (!response.ok) {
+        throw new Error(`Kunne ikke hente allergier (${response.status})`);
+    }
+
+    const allergies = (await response.json()) as PhotonAllergy[];
+    return allergies.map(toAllergy);
+}

--- a/app/(app)/(tabs)/profil/_layout.tsx
+++ b/app/(app)/(tabs)/profil/_layout.tsx
@@ -40,7 +40,28 @@ export default function ProfilLayout() {
                             )}
                         </Pressable>
                     ),
+                    // Bjella har høyre side for seg selv. Tannhjulet ligger i
+                    // profilhodet i stedet — to knapper her ble for trangt.
                     headerRight: () => <NotificationBell />,
+                }}
+            />
+            <Stack.Screen
+                name="innstillinger"
+                options={{
+                    headerShown: true,
+                    title: "Innstillinger",
+                    headerTitleAlign: "center",
+                    // Bjella følger med hit også, slik at varsler er like
+                    // tilgjengelige som på fanene den ligger på ellers.
+                    headerRight: () => <NotificationBell />,
+                }}
+            />
+            <Stack.Screen
+                name="allergier"
+                options={{
+                    headerShown: true,
+                    title: "Allergier",
+                    headerTitleAlign: "center",
                 }}
             />
         </Stack>

--- a/app/(app)/(tabs)/profil/allergier.tsx
+++ b/app/(app)/(tabs)/profil/allergier.tsx
@@ -1,0 +1,267 @@
+import type { Allergy, UserSettings } from "@/actions/types";
+import {
+    fetchAllergies,
+    mySettings,
+    settingsKeys,
+    updateMySettings,
+} from "@/actions/users/settings";
+import PageWrapper from "@/components/ui/pagewrapper";
+import { Text } from "@/components/ui/text";
+import { themeColors } from "@/lib/theme/colors";
+import { useColorScheme } from "@/lib/useColorScheme";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Plus, Search, X } from "lucide-react-native";
+import { useMemo, useState } from "react";
+import {
+    ActivityIndicator,
+    FlatList,
+    Pressable,
+    TextInput,
+    View,
+} from "react-native";
+import Toast from "react-native-toast-message";
+
+/**
+ * Katalogen er over hundre rader lang — Leptons fritekstsvar ble importert som
+ * én rad hver — så lista vises ikke i sin helhet før noen har søkt.
+ */
+const MAX_SUGGESTIONS = 25;
+
+export default function Allergier() {
+    const router = useRouter();
+    const queryClient = useQueryClient();
+    const { isDarkColorScheme } = useColorScheme();
+    const [search, setSearch] = useState("");
+    /** `null` fram til innstillingene er hentet, så valget kan starte på dem. */
+    const [selected, setSelected] = useState<string[] | null>(null);
+
+    const settings = useQuery({
+        queryKey: settingsKeys.mine,
+        queryFn: mySettings,
+    });
+
+    const allergies = useQuery({
+        queryKey: settingsKeys.allergies,
+        queryFn: fetchAllergies,
+        // Katalogen er den samme for alle og endres nesten aldri.
+        staleTime: 60 * 60 * 1000,
+    });
+
+    const save = useMutation({
+        mutationFn: (slugs: string[]) => updateMySettings({ allergies: slugs }),
+        onSuccess: (updated: UserSettings) => {
+            queryClient.setQueryData(settingsKeys.mine, updated);
+            Toast.show({ type: "success", text1: "Allergiene er lagret" });
+            router.back();
+        },
+        onError: (error) => {
+            Toast.show({
+                type: "error",
+                text1: "Allergiene ble ikke lagret",
+                text2: error.message,
+            });
+        },
+    });
+
+    // Egen memo, ikke en løs `??`-kjede: uten den er lista et nytt objekt ved
+    // hver render, og forslagene under regnes ut på nytt hver gang.
+    const current = useMemo(
+        () => selected ?? settings.data?.allergies ?? [],
+        [selected, settings.data?.allergies],
+    );
+
+    const bySlug = useMemo(
+        () => new Map((allergies.data ?? []).map((a) => [a.slug, a])),
+        [allergies.data],
+    );
+
+    const suggestions = useMemo(() => {
+        const needle = search.trim().toLowerCase();
+        const chosen = new Set(current);
+
+        return (allergies.data ?? [])
+            .filter(
+                (allergy) =>
+                    !chosen.has(allergy.slug) &&
+                    (needle === "" || allergy.label.toLowerCase().includes(needle)),
+            )
+            .slice(0, MAX_SUGGESTIONS);
+    }, [allergies.data, current, search]);
+
+    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
+
+    if (settings.isPending || allergies.isPending) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="flex-1 items-center justify-center">
+                    <ActivityIndicator size="large" />
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    if (settings.isError || allergies.isError) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="flex-1 items-center justify-center px-6">
+                    <Text className="text-base text-destructive text-center">
+                        {(settings.error ?? allergies.error)?.message}
+                    </Text>
+                    <Pressable
+                        onPress={() => {
+                            settings.refetch();
+                            allergies.refetch();
+                        }}
+                        className="mt-6 h-12 px-6 rounded-2xl items-center justify-center bg-primary active:opacity-80"
+                    >
+                        <Text className="text-white text-base font-semibold">
+                            Prøv igjen
+                        </Text>
+                    </Pressable>
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    const toggle = (slug: string) => {
+        setSelected(
+            current.includes(slug)
+                ? current.filter((s) => s !== slug)
+                : [...current, slug],
+        );
+    };
+
+    // Lagringen er ett kall som erstatter hele settet, så knappen står til
+    // slutt framfor at hvert trykk sender en oppdatering.
+    const isUnchanged =
+        selected === null ||
+        (selected.length === settings.data.allergies.length &&
+            selected.every((slug) => settings.data.allergies.includes(slug)));
+
+    return (
+        <PageWrapper className="flex-1 bg-background">
+            <View className="flex-1">
+                <FlatList
+                    data={suggestions}
+                    keyboardDismissMode="on-drag"
+                    keyboardShouldPersistTaps="handled"
+                    contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 24 }}
+                    ListHeaderComponent={
+                        <View className="pt-4">
+                            <Text className="text-sm text-muted-foreground mb-4">
+                                Allergiene dine deles med arrangørene av arrangementene du
+                                melder deg på.
+                            </Text>
+
+                            {current.length > 0 ? (
+                                <View className="flex-row flex-wrap gap-2 mb-4">
+                                    {current.map((slug) => (
+                                        <Pressable
+                                            key={slug}
+                                            onPress={() => toggle(slug)}
+                                            accessibilityRole="button"
+                                            accessibilityLabel={`Fjern ${bySlug.get(slug)?.label ?? slug}`}
+                                            className="flex-row items-center bg-primary/10 dark:bg-primary/20 rounded-full pl-3 pr-2 py-1.5 active:opacity-70"
+                                        >
+                                            <Text className="text-sm font-medium text-primary">
+                                                {bySlug.get(slug)?.label ?? slug}
+                                            </Text>
+                                            <X
+                                                size={14}
+                                                color={themeColors(isDarkColorScheme).primary}
+                                                style={{ marginLeft: 6 }}
+                                            />
+                                        </Pressable>
+                                    ))}
+                                </View>
+                            ) : (
+                                <Text className="text-muted-foreground mb-4">
+                                    Ingen allergier registrert.
+                                </Text>
+                            )}
+
+                            <View className="flex-row items-center bg-gray-100 dark:bg-secondary/30 rounded-2xl px-4 h-12 mb-2">
+                                <Search size={18} color={mutedColor} />
+                                <TextInput
+                                    className="flex-1 ml-3 text-foreground"
+                                    placeholder="Søk etter allergi..."
+                                    placeholderTextColor={mutedColor}
+                                    value={search}
+                                    onChangeText={setSearch}
+                                    autoCapitalize="none"
+                                    autoCorrect={false}
+                                    inputMode="search"
+                                    returnKeyType="search"
+                                    style={{
+                                        fontFamily: "Inter",
+                                        fontSize: 16,
+                                        lineHeight: 20,
+                                        paddingTop: 0,
+                                        paddingBottom: 0,
+                                    }}
+                                />
+                                {search.length > 0 ? (
+                                    <Pressable onPress={() => setSearch("")} className="p-1">
+                                        <X size={16} color={mutedColor} />
+                                    </Pressable>
+                                ) : null}
+                            </View>
+                        </View>
+                    }
+                    renderItem={({ item }: { item: Allergy }) => (
+                        <Pressable
+                            onPress={() => toggle(item.slug)}
+                            accessibilityRole="button"
+                            className="flex-row items-center py-3.5 active:opacity-70"
+                        >
+                            <Text className="flex-1 text-base text-foreground">
+                                {item.label}
+                            </Text>
+                            <Plus size={18} color={mutedColor} />
+                        </Pressable>
+                    )}
+                    keyExtractor={(item) => item.slug}
+                    ItemSeparatorComponent={() => (
+                        <View className="h-px bg-border dark:bg-muted" />
+                    )}
+                    ListEmptyComponent={
+                        <View className="py-10 items-center">
+                            <Text className="text-muted-foreground text-center">
+                                {search
+                                    ? "Ingen allergier matcher søket"
+                                    : "Alle allergiene i katalogen er valgt"}
+                            </Text>
+                        </View>
+                    }
+                />
+
+                {/* Faneraden flyter over innholdet, så knappen trenger luft
+                    under seg for ikke å ligge klemt inntil den. */}
+                <View className="px-5 pb-6 pt-2 border-t border-border dark:border-muted">
+                    <Pressable
+                        onPress={() => save.mutate(current)}
+                        disabled={isUnchanged || save.isPending}
+                        className={`h-14 rounded-2xl items-center justify-center ${
+                            isUnchanged || save.isPending
+                                ? "bg-gray-100 dark:bg-secondary/30"
+                                : "bg-primary active:opacity-80"
+                        }`}
+                    >
+                        {save.isPending ? (
+                            <ActivityIndicator />
+                        ) : (
+                            <Text
+                                className={`text-base font-semibold ${
+                                    isUnchanged ? "text-muted-foreground" : "text-white"
+                                }`}
+                            >
+                                Lagre
+                            </Text>
+                        )}
+                    </Pressable>
+                </View>
+            </View>
+        </PageWrapper>
+    );
+}

--- a/app/(app)/(tabs)/profil/index.tsx
+++ b/app/(app)/(tabs)/profil/index.tsx
@@ -1,74 +1,68 @@
-import { avatarImageUrl } from "@/lib/images";
-import { themeColors } from "@/lib/theme/colors";
-import me, { myEvents } from "@/actions/users/me";
-import PageWrapper from "@/components/ui/pagewrapper";
-import { Text } from "@/components/ui/text";
-import { useAuth } from "@/context/auth";
-import { deleteToken } from "@/lib/storage/tokenStore";
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
-import { useRouter } from "expo-router";
-import { Image, Pressable, View } from "react-native";
-import Toast from "react-native-toast-message";
+import { fetchFavoriteEvents } from "@/actions/events/events";
 import { Event } from "@/actions/types";
+import me, { myEvents } from "@/actions/users/me";
 import EventCard, {
     EventCardSkeleton,
 } from "@/components/arrangement/eventCard";
-import useRefresh from "@/lib/useRefresh";
-import { Mail, GraduationCap, LogOut, TriangleAlert } from "lucide-react-native";
+import PageWrapper from "@/components/ui/pagewrapper";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Text } from "@/components/ui/text";
+import { useAuth } from "@/context/auth";
+import { avatarImageUrl } from "@/lib/images";
+import { classYearLabel, parseStartYear } from "@/lib/study";
+import { themeColors } from "@/lib/theme/colors";
 import { useColorScheme } from "@/lib/useColorScheme";
-import { SectionHeader } from "@/components/ui/section-header";
-import { ThemeSwitch } from "@/components/themeToggle";
-import { useRef } from "react";
-import { GestureHandlerRootView, ScrollView } from "react-native-gesture-handler";
-import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
-import { InteropBottomSheetModal } from "@/lib/interopBottomSheet";
+import useRefresh from "@/lib/useRefresh";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { Settings } from "lucide-react-native";
+import { useState } from "react";
+import { Image, Pressable, View } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+
+/** Fanene under profilen. Rekkefølgen styrer `SegmentedControl`. */
+const TABS = ["Påmeldte", "Favoritter"] as const;
 
 export default function Profil() {
-    const { setAuthState } = useAuth();
+    const { signOut } = useAuth();
     const router = useRouter();
     const { isDarkColorScheme } = useColorScheme();
-    const logoutSheetRef = useRef<BottomSheetModal>(null);
+    const [tab, setTab] = useState(0);
 
     const user = useQuery({
         queryKey: ["users", "me"],
         queryFn: me,
     });
 
-    const userEvents = useQuery({
+    const registered = useQuery({
         queryKey: ["users", "me", "events"],
         queryFn: myEvents,
     });
 
-    const refreshControl = useRefresh(["users", "me"]);
+    // Favorittlista koster ett kall per favoritt hos Photon, så den hentes
+    // først når fanen faktisk åpnes.
+    const favorites = useQuery({
+        queryKey: ["events", "favorites", "upcoming"],
+        queryFn: () => fetchFavoriteEvents({ expired: false }),
+        enabled: tab === 1,
+    });
 
-
-    const mutedColor = themeColors(isDarkColorScheme).mutedForeground;
-
-    const performLogout = async () => {
-        const isLoggedOut = await deleteToken();
-
-        if (!isLoggedOut) {
-            return Toast.show({
-                type: "error",
-                text1: "Feil",
-                text2: "Kunne ikke logge ut. Prøv igjen.",
-            });
-        }
-
-        setAuthState!({
-            auhtenticated: false,
-            isLoading: false,
-            token: null,
-        });
-        router.replace("/(auth)/login");
-    };
+    const refreshControl = useRefresh([
+        ["users", "me"],
+        ["events", "favorites"],
+    ]);
 
     if (user.isPending) {
         return (
             <PageWrapper className="flex-1 bg-background">
-                <ScrollView refreshControl={refreshControl} contentContainerStyle={{flexGrow: 1}}>
+                <ScrollView
+                    refreshControl={refreshControl}
+                    contentContainerStyle={{ flexGrow: 1 }}
+                >
                     <View className="flex-1 items-center justify-center">
-                        <Text className="text-base text-muted-foreground">Laster profil...</Text>
+                        <Text className="text-base text-muted-foreground">
+                            Laster profil...
+                        </Text>
                     </View>
                 </ScrollView>
             </PageWrapper>
@@ -78,21 +72,35 @@ export default function Profil() {
     if (user.isError) {
         return (
             <PageWrapper className="flex-1 bg-background">
-                <ScrollView refreshControl={refreshControl} contentContainerStyle={{flexGrow: 1}}>
+                <ScrollView
+                    refreshControl={refreshControl}
+                    contentContainerStyle={{ flexGrow: 1 }}
+                >
                     {/*
-                      * «Logg ut» hører hjemme her også. Ligger den bare i den
-                      * ferdiglastede profilen, er den utilgjengelig akkurat når
-                      * den trengs mest — når profilen ikke lar seg hente.
+                      * «Logg ut» hører hjemme her også. Ligger den bare i
+                      * innstillingene, er den utilgjengelig akkurat når den
+                      * trengs mest — når profilen ikke lar seg hente.
                       */}
                     <View className="flex-1 items-center justify-center px-6">
-                        <Text className="text-base text-destructive text-center">{user.error.message}</Text>
+                        <Text className="text-base text-destructive text-center">
+                            {user.error.message}
+                        </Text>
                         <Pressable
                             onPress={() => user.refetch()}
                             className="mt-6 h-12 px-6 rounded-2xl items-center justify-center bg-primary active:opacity-80"
                         >
-                            <Text className="text-white text-base font-semibold">Prøv igjen</Text>
+                            <Text className="text-white text-base font-semibold">
+                                Prøv igjen
+                            </Text>
                         </Pressable>
-                        <Pressable onPress={performLogout} hitSlop={8} className="mt-4">
+                        <Pressable
+                            onPress={async () => {
+                                await signOut?.();
+                                router.replace("/(auth)/login");
+                            }}
+                            hitSlop={8}
+                            className="mt-4"
+                        >
                             <Text className="text-base text-primary">Logg ut</Text>
                         </Pressable>
                     </View>
@@ -101,146 +109,139 @@ export default function Profil() {
         );
     }
 
-    const initials = `${user.data.first_name[0]}${user.data.last_name[0]}`;
+    const initials = `${user.data.first_name[0] ?? ""}${user.data.last_name[0] ?? ""}`;
+    const studyProgram = user.data.study.group.name || null;
+    const classLabel = classYearLabel(
+        studyProgram ?? undefined,
+        parseStartYear(user.data.studyyear.group.name),
+    );
 
-    const handleLogoutConfirm = async () => {
-        logoutSheetRef.current?.dismiss();
-        await performLogout();
-    };
+    const events = tab === 0 ? registered : favorites;
 
     return (
-        <GestureHandlerRootView style={{ flex: 1 }}>
-            <PageWrapper className="flex-1 bg-background">
-                <ScrollView
-                    refreshControl={refreshControl}
-                    showsVerticalScrollIndicator={false}
-                    contentContainerStyle={{paddingBottom: 100}}
-                >
-                    {/* Profile hero */}
-                    <View className="items-center pt-8 pb-6">
-                        {user.data.image ? (
-                            <Image
-                                className="w-28 h-28 rounded-full"
-                                source={{ uri: avatarImageUrl(user.data.image) }}
-                                resizeMode="cover"
-                            />
-                        ) : (
-                            <View className="w-28 h-28 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
-                                <Text className="text-3xl font-bold text-primary">
-                                    {initials}
-                                </Text>
-                            </View>
-                        )}
+        <PageWrapper className="flex-1 bg-background">
+            <ScrollView
+                refreshControl={refreshControl}
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingBottom: 100 }}
+            >
+                {/* Profilhode: bilde til venstre, opplysningene til høyre */}
+                <View className="flex-row items-center px-5 pt-6 pb-7">
+                    {user.data.image ? (
+                        <Image
+                            className="w-20 h-20 rounded-full"
+                            source={{ uri: avatarImageUrl(user.data.image) }}
+                            resizeMode="cover"
+                        />
+                    ) : (
+                        <View className="w-20 h-20 rounded-full bg-primary/15 dark:bg-primary/25 items-center justify-center">
+                            <Text className="text-2xl font-bold text-primary">
+                                {initials}
+                            </Text>
+                        </View>
+                    )}
 
-                        <Text className="text-2xl font-bold mt-4 text-foreground">
+                    <View className="flex-1 ml-4">
+                        <Text
+                            className="text-xl font-bold text-foreground"
+                            numberOfLines={2}
+                        >
                             {user.data.first_name} {user.data.last_name}
                         </Text>
-                        <Text className="text-base text-muted-foreground mt-0.5">
-                            @{user.data.user_id}
-                        </Text>
+                        <MetaRow
+                            left={`@${user.data.user_id}`}
+                            right={user.data.email || null}
+                        />
+                        <MetaRow left={studyProgram} right={classLabel} />
                     </View>
 
-                    {/* Info section */}
-                    <View className="px-6 mb-6">
-                        <View className="bg-gray-100 dark:bg-secondary/30 rounded-2xl overflow-hidden">
-                            {/* Study */}
-                            <View className="flex-row items-center px-4 py-3.5">
-                                <GraduationCap size={18} color={mutedColor} />
-                                <Text className="text-base text-foreground ml-3">
-                                    {user.data.study.group.name}
-                                </Text>
-                            </View>
+                    {/*
+                      * Innstillingene ligger her, ikke i headeren: der har
+                      * bjella høyre side alene, og et tannhjul inntil den ble
+                      * to knapper som klemte hverandre.
+                      */}
+                    <Pressable
+                        onPress={() => router.push("/(app)/(tabs)/profil/innstillinger")}
+                        hitSlop={10}
+                        accessibilityRole="button"
+                        accessibilityLabel="Innstillinger"
+                        className="w-10 h-10 rounded-full bg-gray-100 dark:bg-secondary/30 items-center justify-center ml-3 active:opacity-70"
+                    >
+                        <Settings
+                            size={19}
+                            strokeWidth={2}
+                            color={themeColors(isDarkColorScheme).foreground}
+                        />
+                    </Pressable>
+                </View>
 
-                            <View className="h-px bg-border dark:bg-muted ml-12" />
-
-                            {/* Email */}
-                            <View className="flex-row items-center px-4 py-3.5">
-                                <Mail size={18} color={mutedColor} />
-                                <Text className="text-base text-foreground ml-3">
-                                    {user.data.email}
-                                </Text>
-                            </View>
-                        </View>
-                    </View>
-
-                    {/* Tema */}
-                    <View className="px-6 mb-6">
-                        <ThemeSwitch />
-                    </View>
-
-                    {/* Events */}
-                    <View className="px-6 mb-6">
-                        <SectionHeader title="Påmeldte arrangementer" />
-                        <DisplayUserEvents userEvents={userEvents} router={router} />
-                    </View>
-
-                    {/* Logout */}
-                    <View className="px-6 mt-2">
-                        <Pressable
-                            onPress={() => logoutSheetRef.current?.present()}
-                            className="flex-row items-center justify-center h-14 rounded-2xl bg-destructive/10 dark:bg-destructive/20 active:opacity-70"
-                        >
-                            <LogOut size={18} color={themeColors(isDarkColorScheme).destructive} />
-                            <Text className="text-base font-semibold text-destructive ml-2">
-                                Logg ut
-                            </Text>
-                        </Pressable>
-                    </View>
-
-                    <InteropBottomSheetModal ref={logoutSheetRef}
-                        backgroundStyleClassName="bg-popover rounded-3xl"
-                        enableDynamicSizing
-                        backdropComponent={(props) => (
-                            <BottomSheetBackdrop
-                                opacity={0.5}
-                                appearsOnIndex={0}
-                                disappearsOnIndex={-1}
-                                {...props}
-                            />
-                        )} >
-                        <BottomSheetView className="bg-popover px-6 pb-10 pt-6">
-                            <View className="items-center mb-4">
-                                <View className="w-14 h-14 rounded-full bg-destructive/10 dark:bg-destructive/20 items-center justify-center mb-4">
-                                    <TriangleAlert size={26} color={themeColors(isDarkColorScheme).destructive} />
-                                </View>
-                                <Text className="text-xl font-bold text-foreground text-center">
-                                    Logg ut
-                                </Text>
-                                <Text className="text-sm text-muted-foreground text-center mt-1">
-                                    Er du sikker på at du vil logge ut av TIHLDE?
-                                </Text>
-                            </View>
-                            <View className="gap-y-2">
-                                <Pressable
-                                    onPress={handleLogoutConfirm}
-                                    className="h-12 rounded-2xl bg-destructive items-center justify-center active:opacity-80"
-                                >
-                                    <Text className="text-white text-base font-semibold" style={{ fontFamily: "Inter" }}>
-                                        Logg ut
-                                    </Text>
-                                </Pressable>
-                                <Pressable
-                                    onPress={() => logoutSheetRef.current?.dismiss()}
-                                    className="h-12 rounded-2xl bg-gray-100 dark:bg-secondary/30 items-center justify-center active:bg-gray-200 dark:active:bg-secondary/50"
-                                >
-                                    <Text className="text-base font-medium text-foreground" style={{ fontFamily: "Inter" }}>
-                                        Avbryt
-                                    </Text>
-                                </Pressable>
-                            </View>
-                        </BottomSheetView>
-                    </InteropBottomSheetModal>
-                </ScrollView>
-            </PageWrapper>
-        </GestureHandlerRootView>
+                {/* Arrangementer: påmeldte eller favoritter */}
+                <View className="px-5">
+                    <SegmentedControl
+                        className="mb-5"
+                        options={[...TABS]}
+                        value={tab}
+                        onChange={setTab}
+                    />
+                    <DisplayUserEvents
+                        userEvents={events}
+                        router={router}
+                        emptyText={
+                            tab === 0
+                                ? "Du er ikke påmeldt noen arrangementer"
+                                : "Du har ingen favorittmerkede arrangementer"
+                        }
+                    />
+                </View>
+            </ScrollView>
+        </PageWrapper>
     );
 }
 
-function DisplayUserEvents({ userEvents, router }: {
+/**
+ * En linje med to opplysninger: den venstre står først, den høyre etter en
+ * prikk. Mangler den ene, faller prikken bort sammen med den.
+ *
+ * Den høyre får resten av bredden og kuttes med «…» — e-postadresser er
+ * lengre enn det er plass til ved siden av brukernavnet på de smaleste
+ * telefonene.
+ */
+function MetaRow({ left, right }: { left: string | null; right: string | null }) {
+    if (!left && !right) return null;
+
+    return (
+        <View className="flex-row items-center mt-1">
+            {left ? (
+                <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+                    {left}
+                </Text>
+            ) : null}
+            {left && right ? (
+                <View className="w-1 h-1 rounded-full bg-muted-foreground/60 mx-2" />
+            ) : null}
+            {right ? (
+                <Text
+                    className="text-sm text-muted-foreground flex-1"
+                    numberOfLines={1}
+                >
+                    {right}
+                </Text>
+            ) : null}
+        </View>
+    );
+}
+
+function DisplayUserEvents({
+    userEvents,
+    router,
+    emptyText,
+}: {
     userEvents: UseQueryResult<{ results: Event[] }, Error>;
     router: ReturnType<typeof useRouter>;
+    emptyText: string;
 }) {
-
+    // `isPending` er sann også for en spørring som ikke har startet ennå
+    // (favorittfanen før den åpnes), så skjelettene dekker begge tilfellene.
     if (userEvents.isPending) {
         return (
             <>
@@ -252,15 +253,17 @@ function DisplayUserEvents({ userEvents, router }: {
     }
 
     if (userEvents.isError) {
-        return <Text className="text-destructive text-center py-4">{userEvents.error.message}</Text>;
+        return (
+            <Text className="text-destructive text-center py-4">
+                {userEvents.error.message}
+            </Text>
+        );
     }
 
     if (userEvents.data.results.length === 0) {
         return (
             <View className="py-8 items-center">
-                <Text className="text-muted-foreground text-center">
-                    Du er ikke påmeldt noen arrangementer
-                </Text>
+                <Text className="text-muted-foreground text-center">{emptyText}</Text>
             </View>
         );
     }
@@ -272,10 +275,11 @@ function DisplayUserEvents({ userEvents, router }: {
             title={event.title}
             date={new Date(event.start_date)}
             image={event.image ?? null}
+            location={event.location ?? null}
             organizer={event.organizer ?? { name: "Ukjent", slug: null }}
             onPress={() => {
                 router.push({
-                    pathname: "/(modals)/arrangement/[arrangementId]",
+                    pathname: "/(app)/(modals)/arrangement/[arrangementId]",
                     params: { arrangementId: event.id },
                 });
             }}

--- a/app/(app)/(tabs)/profil/innstillinger.tsx
+++ b/app/(app)/(tabs)/profil/innstillinger.tsx
@@ -1,0 +1,446 @@
+import type { NotificationChannel, UserSettings } from "@/actions/types";
+import {
+    mySettings,
+    settingsKeys,
+    updateMySettings,
+} from "@/actions/users/settings";
+import { ThemeSwitch } from "@/components/themeToggle";
+import PageWrapper from "@/components/ui/pagewrapper";
+import { SectionHeader } from "@/components/ui/section-header";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Switch } from "@/components/ui/switch";
+import { Text } from "@/components/ui/text";
+import { useAuth } from "@/context/auth";
+import { InteropBottomSheetModal } from "@/lib/interopBottomSheet";
+import { isPushEnabled, setPushEnabled } from "@/lib/notifications/push";
+import { themeColors } from "@/lib/theme/colors";
+import { useColorScheme } from "@/lib/useColorScheme";
+import useRefresh from "@/lib/useRefresh";
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import {
+    ChevronRight,
+    LogOut,
+    TriangleAlert,
+} from "lucide-react-native";
+import { useRef } from "react";
+import { ActivityIndicator, Pressable, View } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+import Toast from "react-native-toast-message";
+
+/** Rekkefølgen i bryteren, og etikettene som vises. */
+const CHANNELS: { value: NotificationChannel; label: string }[] = [
+    { value: "none", label: "Ingen" },
+    { value: "email", label: "E-post" },
+    { value: "push", label: "Telefon" },
+    { value: "both", label: "Begge" },
+];
+
+const pushQueryKey = ["notifications", "push-enabled"];
+
+/** De to underliggende bryterne som ett valg. */
+function toChannel(mail: boolean, push: boolean): NotificationChannel {
+    if (mail && push) return "both";
+    if (mail) return "email";
+    if (push) return "push";
+    return "none";
+}
+
+export default function Innstillinger() {
+    const { signOut } = useAuth();
+    const router = useRouter();
+    const queryClient = useQueryClient();
+    const { isDarkColorScheme } = useColorScheme();
+    const logoutSheetRef = useRef<BottomSheetModal>(null);
+
+    const settings = useQuery({
+        queryKey: settingsKeys.mine,
+        queryFn: mySettings,
+    });
+
+    const pushEnabled = useQuery({
+        queryKey: pushQueryKey,
+        queryFn: isPushEnabled,
+    });
+
+    const refreshControl = useRefresh([settingsKeys.mine, pushQueryKey]);
+
+    /**
+     * Bryterne leser verdien fra spørringen, ikke fra egen tilstand. Uten det
+     * optimistiske hoppet ville de stått igjen på gammel verdi til Photon
+     * svarte, som ser ut som at trykket ikke ble registrert.
+     */
+    const update = useMutation({
+        mutationFn: (updates: Partial<UserSettings>) => updateMySettings(updates),
+        onMutate: async (updates) => {
+            await queryClient.cancelQueries({ queryKey: settingsKeys.mine });
+            const previous = queryClient.getQueryData<UserSettings>(settingsKeys.mine);
+
+            if (previous) {
+                queryClient.setQueryData<UserSettings>(settingsKeys.mine, {
+                    ...previous,
+                    ...updates,
+                });
+            }
+
+            return { previous };
+        },
+        onError: (error, _updates, context) => {
+            if (context?.previous) {
+                queryClient.setQueryData(settingsKeys.mine, context.previous);
+            }
+            Toast.show({
+                type: "error",
+                text1: "Innstillingen ble ikke lagret",
+                text2: error.message,
+            });
+        },
+        onSuccess: (updated) => {
+            queryClient.setQueryData(settingsKeys.mine, updated);
+        },
+    });
+
+    /**
+     * E-post er en innstilling i Photon, push er om telefonen er meldt på.
+     * Bryteren setter begge i én handling, så brukeren slipper å vite det.
+     *
+     * Push først: går den ikke gjennom, står e-posten urørt. Ellers ville
+     * «Telefon» endt som «Ingen» — valget slo av e-posten og fikk aldri på
+     * push — og skjermen hoppet til noe brukeren ikke hadde bedt om.
+     */
+    const changeChannel = useMutation({
+        mutationFn: async (channel: NotificationChannel) => {
+            const wantsMail = channel === "email" || channel === "both";
+            const wantsPush = channel === "push" || channel === "both";
+
+            if (wantsPush !== (pushEnabled.data ?? true)) {
+                const result = await setPushEnabled(wantsPush);
+                queryClient.setQueryData(pushQueryKey, wantsPush && result === "ok");
+                if (result !== "ok") return result;
+            }
+
+            if (wantsMail !== (settings.data?.receiveMailCommunication ?? true)) {
+                const updated = await updateMySettings({
+                    receiveMailCommunication: wantsMail,
+                });
+                queryClient.setQueryData(settingsKeys.mine, updated);
+            }
+
+            return "ok" as const;
+        },
+        onSuccess: (result) => {
+            if (result === "denied") {
+                Toast.show({
+                    type: "error",
+                    text1: "Varsler er avslått",
+                    text2: "Skru på varsler for TIHLDE i innstillingene på telefonen.",
+                });
+            }
+
+            // Uten denne ser «Telefon» og «Begge» ut som knapper som ikke
+            // virker: valget spretter tilbake, og ingenting sier hvorfor.
+            if (result === "unavailable") {
+                Toast.show({
+                    type: "error",
+                    text1: "Push-varsler er ikke tilgjengelig her",
+                    text2: "Denne enheten kan ikke motta push. Prøv på en fysisk telefon.",
+                });
+            }
+        },
+        onError: (error) => {
+            Toast.show({
+                type: "error",
+                text1: "Innstillingen ble ikke lagret",
+                text2: error.message,
+            });
+        },
+    });
+
+    if (settings.isPending) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="flex-1 items-center justify-center">
+                    <ActivityIndicator size="large" />
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    if (settings.isError) {
+        return (
+            <PageWrapper className="flex-1 bg-background">
+                <View className="flex-1 items-center justify-center px-6">
+                    <Text className="text-base text-destructive text-center">
+                        {settings.error.message}
+                    </Text>
+                    <Pressable
+                        onPress={() => settings.refetch()}
+                        className="mt-6 h-12 px-6 rounded-2xl items-center justify-center bg-primary active:opacity-80"
+                    >
+                        <Text className="text-white text-base font-semibold">
+                            Prøv igjen
+                        </Text>
+                    </Pressable>
+                </View>
+            </PageWrapper>
+        );
+    }
+
+    const current = settings.data;
+    const channel = toChannel(
+        current.receiveMailCommunication,
+        pushEnabled.data ?? true,
+    );
+    const channelIndex = CHANNELS.findIndex((option) => option.value === channel);
+
+    const allergyCount = current.allergies.length;
+
+    const handleLogoutConfirm = async () => {
+        logoutSheetRef.current?.dismiss();
+        await signOut?.();
+        router.replace("/(auth)/login");
+    };
+
+    return (
+        <PageWrapper className="flex-1 bg-background">
+            <ScrollView
+                refreshControl={refreshControl}
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingBottom: 60 }}
+            >
+                {/* Utseende */}
+                <View className="px-5 pt-5">
+                    <SectionHeader title="Utseende" />
+                    <ThemeSwitch />
+                </View>
+
+                {/* Arrangementer */}
+                <View className="px-5 pt-6">
+                    <SectionHeader title="Arrangementer" />
+
+                    {!current.acceptsEventRules ? (
+                        <View className="flex-row items-start bg-destructive/10 dark:bg-destructive/20 rounded-2xl px-4 py-3.5 mb-3">
+                            <TriangleAlert
+                                size={18}
+                                color={themeColors(isDarkColorScheme).destructive}
+                            />
+                            <Text className="flex-1 text-sm text-destructive ml-3">
+                                Du må godta arrangementsreglene før du kan melde deg på
+                                arrangementer.
+                            </Text>
+                        </View>
+                    ) : null}
+
+                    <SettingGroup>
+                        <SwitchRow
+                            title="Arrangementsregler"
+                            description="Jeg har lest og godtar TIHLDEs regler for arrangementer."
+                            checked={current.acceptsEventRules}
+                            disabled={update.isPending}
+                            onCheckedChange={(value) =>
+                                update.mutate({ acceptsEventRules: value })
+                            }
+                            nativeID="accepts-event-rules"
+                        />
+                        <RowDivider />
+                        <LinkRow
+                            title="Allergier"
+                            description={
+                                allergyCount === 0
+                                    ? "Ingen registrert"
+                                    : `${allergyCount} registrert`
+                            }
+                            onPress={() => router.push("/(app)/(tabs)/profil/allergier")}
+                        />
+                    </SettingGroup>
+                </View>
+
+                {/* Personvern */}
+                <View className="px-5 pt-6">
+                    <SectionHeader title="Personvern" />
+                    <SettingGroup>
+                        <SwitchRow
+                            title="Bildesamtykke"
+                            description="Bilder av deg fra arrangementer kan publiseres. Gjelder arrangementer du melder deg på etter at du endrer dette."
+                            checked={current.allowsPhotosByDefault}
+                            disabled={update.isPending}
+                            onCheckedChange={(value) =>
+                                update.mutate({ allowsPhotosByDefault: value })
+                            }
+                            nativeID="allows-photos"
+                        />
+                        <RowDivider />
+                        <SwitchRow
+                            title="Offentlige påmeldinger"
+                            description="Navnet ditt vises i deltakerlister. Skrur du av, står du oppført som anonym for andre medlemmer. Arrangører ser deg uansett."
+                            checked={current.publicEventRegistrations}
+                            disabled={update.isPending}
+                            onCheckedChange={(value) =>
+                                update.mutate({ publicEventRegistrations: value })
+                            }
+                            nativeID="public-registrations"
+                        />
+                    </SettingGroup>
+                </View>
+
+                {/* Varsler */}
+                <View className="px-5 pt-6">
+                    <SectionHeader title="Varsler" />
+                    <SegmentedControl
+                        options={CHANNELS.map((option) => option.label)}
+                        value={channelIndex === -1 ? 0 : channelIndex}
+                        onChange={(index) =>
+                            changeChannel.mutate(CHANNELS[index].value)
+                        }
+                    />
+                    <Text className="text-sm text-muted-foreground mt-2.5">
+                        Hvor du vil høre fra TIHLDE. «Telefon» er push-varsler på denne
+                        telefonen.
+                    </Text>
+                </View>
+
+                {/* Logg ut */}
+                <View className="px-5 pt-8">
+                    <Pressable
+                        onPress={() => logoutSheetRef.current?.present()}
+                        className="flex-row items-center justify-center h-14 rounded-2xl bg-destructive/10 dark:bg-destructive/20 active:opacity-70"
+                    >
+                        <LogOut
+                            size={18}
+                            color={themeColors(isDarkColorScheme).destructive}
+                        />
+                        <Text className="text-base font-semibold text-destructive ml-2">
+                            Logg ut
+                        </Text>
+                    </Pressable>
+                </View>
+
+                <InteropBottomSheetModal
+                    ref={logoutSheetRef}
+                    backgroundStyleClassName="bg-popover rounded-3xl"
+                    enableDynamicSizing
+                    backdropComponent={(props) => (
+                        <BottomSheetBackdrop
+                            opacity={0.5}
+                            appearsOnIndex={0}
+                            disappearsOnIndex={-1}
+                            {...props}
+                        />
+                    )}
+                >
+                    <BottomSheetView className="bg-popover px-6 pb-10 pt-6">
+                        <View className="items-center mb-4">
+                            <View className="w-14 h-14 rounded-full bg-destructive/10 dark:bg-destructive/20 items-center justify-center mb-4">
+                                <TriangleAlert
+                                    size={26}
+                                    color={themeColors(isDarkColorScheme).destructive}
+                                />
+                            </View>
+                            <Text className="text-xl font-bold text-foreground text-center">
+                                Logg ut
+                            </Text>
+                            <Text className="text-sm text-muted-foreground text-center mt-1">
+                                Er du sikker på at du vil logge ut av TIHLDE?
+                            </Text>
+                        </View>
+                        <View className="gap-y-2">
+                            <Pressable
+                                onPress={handleLogoutConfirm}
+                                className="h-12 rounded-2xl bg-destructive items-center justify-center active:opacity-80"
+                            >
+                                <Text className="text-white text-base font-semibold">
+                                    Logg ut
+                                </Text>
+                            </Pressable>
+                            <Pressable
+                                onPress={() => logoutSheetRef.current?.dismiss()}
+                                className="h-12 rounded-2xl bg-gray-100 dark:bg-secondary/30 items-center justify-center active:bg-gray-200 dark:active:bg-secondary/50"
+                            >
+                                <Text className="text-base font-medium text-foreground">
+                                    Avbryt
+                                </Text>
+                            </Pressable>
+                        </View>
+                    </BottomSheetView>
+                </InteropBottomSheetModal>
+            </ScrollView>
+        </PageWrapper>
+    );
+}
+
+function SettingGroup({ children }: { children: React.ReactNode }) {
+    return (
+        <View className="bg-gray-100 dark:bg-secondary/30 rounded-2xl overflow-hidden">
+            {children}
+        </View>
+    );
+}
+
+function RowDivider() {
+    return <View className="h-px bg-border dark:bg-muted mx-4" />;
+}
+
+function SwitchRow({
+    title,
+    description,
+    checked,
+    disabled,
+    onCheckedChange,
+    nativeID,
+}: {
+    title: string;
+    description: string;
+    checked: boolean;
+    disabled?: boolean;
+    onCheckedChange: (value: boolean) => void;
+    nativeID: string;
+}) {
+    return (
+        <View className="flex-row items-center px-4 py-3.5">
+            <View className="flex-1 mr-4">
+                <Text className="text-base text-foreground">{title}</Text>
+                <Text className="text-sm text-muted-foreground mt-0.5">
+                    {description}
+                </Text>
+            </View>
+            <Switch
+                checked={checked}
+                disabled={disabled}
+                onCheckedChange={onCheckedChange}
+                nativeID={nativeID}
+            />
+        </View>
+    );
+}
+
+function LinkRow({
+    title,
+    description,
+    onPress,
+}: {
+    title: string;
+    description: string;
+    onPress: () => void;
+}) {
+    const { isDarkColorScheme } = useColorScheme();
+
+    return (
+        <Pressable
+            onPress={onPress}
+            accessibilityRole="button"
+            className="flex-row items-center px-4 py-3.5 active:opacity-70"
+        >
+            <View className="flex-1 mr-4">
+                <Text className="text-base text-foreground">{title}</Text>
+                <Text className="text-sm text-muted-foreground mt-0.5">
+                    {description}
+                </Text>
+            </View>
+            <ChevronRight
+                size={20}
+                color={themeColors(isDarkColorScheme).mutedForeground}
+            />
+        </Pressable>
+    );
+}

--- a/components/ui/AnimatedPagerView.tsx
+++ b/components/ui/AnimatedPagerView.tsx
@@ -1,8 +1,8 @@
 
 import { useRef, useState } from 'react';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 import PagerView from 'react-native-pager-view';
-import { Text } from './text';
+import { SegmentedControl } from './segmented-control';
 
 
 interface AnimatedPagerViewProps {
@@ -19,25 +19,14 @@ export default function AnimatedPagerView(props: AnimatedPagerViewProps) {
     return (
         <View className={props.className}>
             {/* Tab bar */}
-            <View className="mx-4 mb-4 flex-row bg-gray-100 dark:bg-secondary/30 rounded-2xl p-1">
-                {props.titles.map((title, index) => {
-                    const isActive = activeIndex === index;
-                    return (
-                        <Pressable
-                            className={`flex-1 py-2.5 rounded-xl items-center justify-center ${isActive ? 'bg-primary' : ''}`}
-                            key={index}
-                            onPress={() => requestAnimationFrame(() => pagerViewRef.current?.setPage(index))}
-                        >
-                            <Text
-                                className={`text-base font-semibold ${isActive ? 'text-white' : 'text-muted-foreground'}`}
-                                style={{ fontFamily: "Inter" }}
-                            >
-                                {title}
-                            </Text>
-                        </Pressable>
-                    );
-                })}
-            </View>
+            <SegmentedControl
+                className="mx-4 mb-4"
+                options={props.titles}
+                value={activeIndex}
+                onChange={(index) =>
+                    requestAnimationFrame(() => pagerViewRef.current?.setPage(index))
+                }
+            />
             <PagerView style={{ flex: 1 }}
                 orientation="horizontal"
                 ref={pagerViewRef}

--- a/components/ui/segmented-control.tsx
+++ b/components/ui/segmented-control.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { Pressable, View } from "react-native";
+import { cn } from "@/lib/utils";
+import { Text } from "./text";
+
+interface SegmentedControlProps {
+    options: string[];
+    /** Indeksen i `options` som er valgt. */
+    value: number;
+    onChange: (index: number) => void;
+    className?: string;
+}
+
+/**
+ * Valgbryteren appen bruker over lister og faner.
+ *
+ * Lå tidligere bare inne i `AnimatedPagerView`. Den er trukket ut hit fordi et
+ * valg ikke alltid hører til en pager — profilen bytter mellom to lister uten
+ * å swipe — og de to skal se like ut.
+ */
+const SegmentedControl = React.forwardRef<View, SegmentedControlProps>(
+    ({ options, value, onChange, className }, ref) => {
+        return (
+            <View
+                ref={ref}
+                className={cn(
+                    "flex-row bg-gray-100 dark:bg-secondary/30 rounded-2xl p-1",
+                    className,
+                )}
+            >
+                {options.map((option, index) => {
+                    const isActive = value === index;
+
+                    return (
+                        <Pressable
+                            key={option}
+                            onPress={() => onChange(index)}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: isActive }}
+                            className={cn(
+                                "flex-1 py-2.5 rounded-xl items-center justify-center",
+                                isActive && "bg-primary",
+                            )}
+                        >
+                            <Text
+                                numberOfLines={1}
+                                className={cn(
+                                    "text-base font-semibold",
+                                    isActive ? "text-white" : "text-muted-foreground",
+                                )}
+                            >
+                                {option}
+                            </Text>
+                        </Pressable>
+                    );
+                })}
+            </View>
+        );
+    },
+);
+
+SegmentedControl.displayName = "SegmentedControl";
+
+export { SegmentedControl };

--- a/lib/interopBottomSheet.ts
+++ b/lib/interopBottomSheet.ts
@@ -1,6 +1,18 @@
-import { BottomSheetModal } from "@gorhom/bottom-sheet";
+import { BottomSheetModal, type BottomSheetModalProps } from "@gorhom/bottom-sheet";
 import { cssInterop } from "nativewind";
+import type { ComponentType, RefAttributes } from "react";
 
+/**
+ * `BottomSheetModal` med `backgroundStyleClassName` som Tailwind-klasse.
+ *
+ * Typen settes eksplisitt fordi `cssInterop` legger på en indekssignatur av
+ * strenger for klassenavnene den tar. Den slår ut `children`, så hvert eneste
+ * kallsted fikk «Element is not assignable to string» — en feil om props
+ * ingen faktisk sender.
+ */
 export const InteropBottomSheetModal = cssInterop(BottomSheetModal, {
-  backgroundStyleClassName: "backgroundStyle",
-});
+    backgroundStyleClassName: "backgroundStyle",
+}) as ComponentType<
+    BottomSheetModalProps &
+        RefAttributes<BottomSheetModal> & { backgroundStyleClassName?: string }
+>;

--- a/lib/notifications/push.ts
+++ b/lib/notifications/push.ts
@@ -10,6 +10,57 @@ import {
 } from "@/actions/notifications/devices";
 
 const STORED_TOKEN = "tihlde_push_token";
+const PUSH_PREFERENCE = "tihlde_push_enabled";
+
+/**
+ * Om brukeren vil ha push på denne telefonen.
+ *
+ * Photon har ingen innstilling for det — der finnes bare listen over påmeldte
+ * enheter — så valget hører hjemme på telefonen som er meldt på. Ingen lagret
+ * verdi betyr «ikke svart», og da spør appen om tillatelse som før.
+ */
+export async function isPushEnabled(): Promise<boolean> {
+    return (await AsyncStorage.getItem(PUSH_PREFERENCE)) !== "false";
+}
+
+export type PushEnableResult =
+    /** Telefonen er meldt på. */
+    | "ok"
+    /** Brukeren har sagt nei til varsler i systemdialogen. */
+    | "denied"
+    /** Ingen ekte enhet, eller manglende EAS-prosjekt — ikke noe brukeren gjorde. */
+    | "unavailable";
+
+/**
+ * Skrur push av eller på for telefonen.
+ *
+ * Valget lagres først, slik at `registerForPushNotifications` — som også kjører
+ * ved oppstart — ser det med en gang.
+ */
+export async function setPushEnabled(
+    enabled: boolean,
+): Promise<PushEnableResult> {
+    await AsyncStorage.setItem(PUSH_PREFERENCE, String(enabled));
+
+    if (!enabled) {
+        await unregisterForPushNotifications();
+        return "ok";
+    }
+
+    if (Device.isDevice && (await registerForPushNotifications())) return "ok";
+
+    // Påmeldingen gikk ikke. Valget settes tilbake, ellers ville innstillingen
+    // stått som «på» mens telefonen ikke får noe — og appen ville prøvd på
+    // nytt ved hver oppstart uten å komme lenger.
+    await AsyncStorage.setItem(PUSH_PREFERENCE, "false");
+
+    if (!Device.isDevice) return "unavailable";
+
+    // Systemdialogen kan bare vises én gang. Er svaret nei, må brukeren inn i
+    // telefoninnstillingene — og det må skjermen kunne si fra om.
+    const { status } = await Notifications.getPermissionsAsync();
+    return status === "granted" ? "unavailable" : "denied";
+}
 
 /**
  * Varsler som kommer mens appen er åpen vises ikke av seg selv — uten en
@@ -51,6 +102,10 @@ export async function registerForPushNotifications(): Promise<string | null> {
     // Push krever ekte maskinvare. Simulatoren har ingen enhet å levere til,
     // og getExpoPushTokenAsync kaster der.
     if (!Device.isDevice) return null;
+
+    // Sperren ligger her, ikke bare hos den som kaller: påmeldingen gjentas
+    // ved hver oppstart, og den skal ikke overkjøre et nei fra innstillingene.
+    if (!(await isPushEnabled())) return null;
 
     await ensureAndroidChannel();
 

--- a/lib/study.ts
+++ b/lib/study.ts
@@ -1,0 +1,64 @@
+/**
+ * Klassetrinn ut fra kullet.
+ *
+ * Speiler `computeClassYear`, `programmeLength` og `formatStudyLabel` i
+ * `apps/kvark/src/lib/utils.ts` i Photon-monorepoet, så profilen i appen og på
+ * nettsiden sier det samme om samme bruker.
+ */
+
+/**
+ * Det norske studieåret starter i august, så fra og med august teller man ett
+ * trinn opp. Måned er 0-indeksert, så `>= 7` er august og senere.
+ */
+export function computeClassYear(startYear: number, now = new Date()): number {
+    return now.getFullYear() - startYear + (now.getMonth() >= 7 ? 1 : 0);
+}
+
+/**
+ * Masterprogrammene ved TIHLDE. Alt annet (Dataingeniør, Digital
+ * forretningsutvikling, Digital infrastruktur og cybersikkerhet, Drift,
+ * Informasjonsbehandling) er treårig bachelor. Programnavnene har variert
+ * mellom Lepton-importen og Feide, så vi matcher på det særegne ordet.
+ */
+const MASTER_PROGRAMME_MARKERS = ["samhandling", "transformasjon", "master"];
+
+/** Antall år programmet varer — brukes til å avgjøre når noen er alumni. */
+export function programmeLength(programme: string | undefined): number {
+    if (!programme) return 3;
+    const name = programme.toLowerCase();
+    return MASTER_PROGRAMME_MARKERS.some((marker) => name.includes(marker))
+        ? 5
+        : 3;
+}
+
+/**
+ * «3. klasse» mens man går på studiet, «kull 2022» etterpå.
+ *
+ * Klassetrinnet vises bare så lenge man faktisk studerer — til og med 3. klasse
+ * på bachelor, 5. på master. Er man forbi det, er man alumni, og da er kullet
+ * det riktige å vise framfor et trinn som ikke finnes.
+ *
+ * Gir `null` når vi ikke vet oppstartsåret. Photon lar det stå tomt for
+ * medlemmer som aldri har koblet Feide.
+ */
+export function classYearLabel(
+    programme: string | undefined,
+    startYear: number | undefined,
+    now = new Date(),
+): string | null {
+    if (startYear === undefined || !Number.isFinite(startYear)) return null;
+
+    const classYear = computeClassYear(startYear, now);
+    const isStudying = classYear >= 1 && classYear <= programmeLength(programme);
+
+    return isStudying ? `${classYear}. klasse` : `kull ${startYear}`;
+}
+
+/**
+ * Oppstartsåret slik `toUser` legger det: en streng, tom når Photon ikke vet.
+ */
+export function parseStartYear(value: string | undefined): number | undefined {
+    if (!value) return undefined;
+    const year = Number.parseInt(value, 10);
+    return Number.isFinite(year) ? year : undefined;
+}

--- a/lib/useRefresh.tsx
+++ b/lib/useRefresh.tsx
@@ -2,11 +2,17 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { RefreshControl } from "react-native-gesture-handler";
 
-export default function useRefresh(refreshQueryKey: string | string[]) {
+/**
+ * `string[]` er én nøkkel. `string[][]` er flere nøkler som skal invalideres
+ * samtidig — en skjerm som viser to lister må kunne oppdatere begge.
+ */
+type RefreshQueryKey = string | string[] | string[][];
+
+export default function useRefresh(refreshQueryKey: RefreshQueryKey) {
     const queryClient = useQueryClient();
     let [isRefreshing, setIsRefreshing] = useState(false);
 
-    const queryKey = Array.isArray(refreshQueryKey)
+    const queryKey: (string | string[])[] = Array.isArray(refreshQueryKey)
         ? refreshQueryKey
         : [refreshQueryKey];
     const hasMultipleQueryKeys = Array.isArray(queryKey[0]);
@@ -27,12 +33,16 @@ export default function useRefresh(refreshQueryKey: string | string[]) {
 
         if (hasMultipleQueryKeys) {
             Promise.all(
-                queryKey.map((key) => queryClient.invalidateQueries({ queryKey: key }))
+                (queryKey as string[][]).map((key) =>
+                    queryClient.invalidateQueries({ queryKey: key })
+                )
             ).then(handleFinish);
             return;
         }
 
-        queryClient.invalidateQueries({ queryKey: queryKey }).then(handleFinish);
+        queryClient
+            .invalidateQueries({ queryKey: queryKey as string[] })
+            .then(handleFinish);
     };
 
     return (


### PR DESCRIPTION
Løser #132.

## Profilsiden

Bildet lå sentrert over navnet, og e-post og studieprogram i egne lyseblå kort. Nå ligger bildet til venstre, og opplysningene som vanlig tekst ved siden av:

```
[bilde]  Mathias Strøm
         @mathstr · mathstr@stud.ntnu.no
         Digital forretningsutvikling · 3. klasse
```

Under hodet en bryter mellom **Påmeldte** og **Favoritter**. Favorittlista hentes først når fanen åpnes — Photon har ikke favoritter som filter på arrangementslista, bare et eget endepunkt som svarer med en tynn form, så hvert arrangement må hentes for seg.

Klassetrinnet regnes ut av kullet med samme regler som Kvark (`computeClassYear`/`formatStudyLabel`): «3. klasse» mens man studerer, «kull 2022» etterpå, og fem år på master. Dermed sier profilen det samme om samme bruker i appen og på nettsiden.

Tannhjulet ligger i profilhodet framfor i headeren, der bjella har høyre side for seg selv.

## Innstillinger

Ny skjerm i profil-stacken, med bjella i headeren:

- **Utseende** — temabryteren, som før lå midt på profilen
- **Arrangementer** — arrangementsreglene Photon krever før påmelding (`acceptsEventRules`), med et varsel når de mangler, og allergier
- **Personvern** — bildesamtykke og offentlige påmeldinger, de samme to Kvark har på `/profil/$id/innstillinger`
- **Varsler** — Ingen / E-post / Telefon / Begge
- **Logg ut**, med bekreftelse

Utloggingen går nå gjennom `signOut` fra auth-konteksten i stedet for `deleteToken` direkte. Den gamle knappen hoppet over avmeldingen fra push, så telefonen fortsatte å få varsler for en bruker som hadde logget ut.

### Varselvalget

Photon har ingen samlet innstilling for dette: e-post er `receiveMailCommunication` på brukerinnstillingene, push er om telefonen står i `/notification/device`. De fire valgene er de to kombinert, så brukeren forholder seg til ett spørsmål.

Push forsøkes først. Går den ikke gjennom, står e-posten urørt og brukeren får beskjed — ellers ville «Telefon» endt som «Ingen», fordi valget slo av e-posten og aldri fikk på push. Avslåtte varsler gir «skru dem på i telefoninnstillingene»; en enhet som ikke kan motta push i det hele tatt (simulator, manglende EAS-oppsett) sier det i stedet for å se ut som en knapp som ikke virker.

Push-valget lagres lokalt og sperrer også den automatiske påmeldingen ved oppstart, som tidligere kjørte uansett hva brukeren måtte ønske.

## Allergier

Egen skjerm med søk mot katalogen på `/user/allergy` (108 rader), chips for det valgte, og ett kall som erstatter hele settet ved lagring.

Photon lar dem ikke skrives som fritekst: `user_setting_allergy.allergy_slug` har en fremmednøkkel til `allergy.slug`, og ingen rute skriver til den tabellen. Katalogen finnes bare fordi Lepton-migrasjonen dumpet de gamle fritekstsvarene inn i den. Det er fulgt opp i TIHLDE/Photon#586 — endres det der, kan «Legg til «kiwi»» legges rett inn i søkefeltet her.

## Ellers

- `SegmentedControl` er trukket ut av `AnimatedPagerView`, siden profilen bruker samme bryter uten å swipe. Pageren bruker nå den samme komponenten, så de to kan ikke skli fra hverandre.
- `useRefresh` tar flere nøkler i typen sin også, ikke bare i implementasjonen.
- `InteropBottomSheetModal` har fått en eksplisitt type. `cssInterop` la på en indekssignatur som slo ut `children`, så hvert kallsted ga «Element is not assignable to string» — fire typefeil om props ingen sender.

## Verifisering

Kjørt i simulatoren mot produksjon-Photon: profilhodet, begge faner, hele innstillingsskjermen i lyst og mørkt tema, utloggingsdialogen, lagring av allergier (lagt til og fjernet igjen), og alle fire varselvalg.

`expo lint` gir ingen funn i de nye filene. `npx tsc --noEmit` er uendret mot baseline — 15 preeksisterende feil i repoet, ingen i noen fil denne PR-en tar på; de fire nevnt over er borte.

Ikke dekket: favorittlista er bare sett tom, siden testbrukeren ikke har favoritter. Den bruker samme `fetchFavoriteEvents` og `EventCard` som favorittfilteret på arrangementsfanen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
