### PR TITLE
fix: rydd opp typefeilene så tsc går rent

### DIFF
--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -318,7 +318,7 @@ export default function ArrangementSide() {
                         {permissions.data?.event?.write && event.data.sign_up && (
                             <Pressable
                                 onPress={() => router.push({
-                                    pathname: "/(modals)/arrangement/[arrangementId]/event-register",
+                                    pathname: "/(app)/(modals)/arrangement/[arrangementId]/event-register",
                                     params: { arrangementId: id as string },
                                 })}
                                 className="h-14 rounded-2xl bg-primary/10 dark:bg-primary/20 flex-row items-center justify-center mb-6 active:opacity-70"
@@ -601,13 +601,13 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
             className="bg-popover"
             data={participants}
             stickyHeaderIndices={[0]}
-            renderItem={({ item: registration }) => (
+            renderItem={({ item: registration }: { item: Registration }) => (
                 <>
                     <UserCard user={registration.user_info} />
                     <View className="h-px bg-border dark:bg-muted" />
                 </>
             )}
-            keyExtractor={(item, index) => item.user_info?.user_id?.toString() ?? index.toString()}
+            keyExtractor={(item: Registration, index: number) => item.user_info?.user_id?.toString() ?? index.toString()}
             onEndReached={() => {
                 if (!hasNextPage) return;
                 fetchNextPage();

--- a/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/brukere.tsx
@@ -75,7 +75,7 @@ export default function UserSelection() {
 
     const handleNext = () => {
         router.push({
-            pathname: "/(modals)/boter/[groupSlug]/bekreft",
+            pathname: "/(app)/(modals)/boter/[groupSlug]/bekreft",
             params: {
                 groupSlug,
                 lawId,

--- a/app/(app)/(modals)/boter/[groupSlug]/index.tsx
+++ b/app/(app)/(modals)/boter/[groupSlug]/index.tsx
@@ -46,7 +46,7 @@ export default function LawSelection() {
                     <Pressable
                         onPress={() =>
                             router.push({
-                                pathname: "/(modals)/boter/[groupSlug]/brukere",
+                                pathname: "/(app)/(modals)/boter/[groupSlug]/brukere",
                                 params: {
                                     groupSlug,
                                     lawId: law.id,

--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -235,7 +235,7 @@ export default function Arrangementer() {
                             date={new Date(event.start_date)}
                             image={event.image ?? null}
                             location={event.location}
-                            onPress={() => router.push(`/(modals)/arrangement/${event.id}`)}
+                            onPress={() => router.push(`/(app)/(modals)/arrangement/${event.id}`)}
                             organizer={event.organizer}
                         />
                     )}

--- a/app/(app)/(tabs)/karriere/index.tsx
+++ b/app/(app)/(tabs)/karriere/index.tsx
@@ -54,7 +54,7 @@ export default function Karriere() {
                 {/* Job post list */}
                 <View>
                     {jobposts.data?.results.map((jobpost: any) => (
-                        <Link href={`/(tabs)/karriere/${jobpost.id}`} key={jobpost.id}>
+                        <Link href={`/(app)/(tabs)/karriere/${jobpost.id}`} key={jobpost.id}>
                             <JobPostCard
                                 title={jobpost.title}
                                 jobType={jobpost.job_type}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -12,7 +12,7 @@ export default function Arrangementer() {
     const [showLoading, setShowLoading] = useState<boolean>(true);
 
     useEffect(() => {
-        let timer: NodeJS.Timeout;
+        let timer: ReturnType<typeof setTimeout> | undefined;
 
         if (!authState?.isLoading) {
             // Set a timer to hide the loading screen after 2 seconds

--- a/lib/useInterval.ts
+++ b/lib/useInterval.ts
@@ -2,7 +2,7 @@ import { EffectCallback } from "expo-router";
 import { useEffect, useRef } from "react";
 
 export default function useInterval(callback: EffectCallback, msDelay: number | null) {
-    const savedCallback = useRef<EffectCallback>();
+    const savedCallback = useRef<EffectCallback | undefined>(undefined);
 
     useEffect(() => {
         savedCallback.current = callback;

--- a/lib/useRefresh.tsx
+++ b/lib/useRefresh.tsx
@@ -3,16 +3,22 @@ import { useState } from "react";
 import { RefreshControl } from "react-native-gesture-handler";
 
 /**
- * `string[]` er én nøkkel. `string[][]` er flere nøkler som skal invalideres
+ * `KeyPart[]` er én nøkkel. `KeyPart[][]` er flere nøkler som skal invalideres
  * samtidig — en skjerm som viser to lister må kunne oppdatere begge.
+ *
+ * Delene må tåle mer enn `string`: arrangementslista har filterflagg i
+ * nøkkelen sin (`["events", søk, expired, openForSignUp, userFavorite]`), og
+ * med bare `string` her pekte invalideringen på en annen nøkkel enn den
+ * `useInfiniteQuery` faktisk bruker.
  */
-type RefreshQueryKey = string | string[] | string[][];
+type KeyPart = string | number | boolean | null | undefined;
+type RefreshQueryKey = KeyPart | KeyPart[] | KeyPart[][];
 
 export default function useRefresh(refreshQueryKey: RefreshQueryKey) {
     const queryClient = useQueryClient();
     let [isRefreshing, setIsRefreshing] = useState(false);
 
-    const queryKey: (string | string[])[] = Array.isArray(refreshQueryKey)
+    const queryKey: (KeyPart | KeyPart[])[] = Array.isArray(refreshQueryKey)
         ? refreshQueryKey
         : [refreshQueryKey];
     const hasMultipleQueryKeys = Array.isArray(queryKey[0]);
@@ -33,7 +39,7 @@ export default function useRefresh(refreshQueryKey: RefreshQueryKey) {
 
         if (hasMultipleQueryKeys) {
             Promise.all(
-                (queryKey as string[][]).map((key) =>
+                (queryKey as KeyPart[][]).map((key) =>
                     queryClient.invalidateQueries({ queryKey: key })
                 )
             ).then(handleFinish);
@@ -41,7 +47,7 @@ export default function useRefresh(refreshQueryKey: RefreshQueryKey) {
         }
 
         queryClient
-            .invalidateQueries({ queryKey: queryKey as string[] })
+            .invalidateQueries({ queryKey: queryKey as KeyPart[] })
             .then(handleFinish);
     };
 


### PR DESCRIPTION
`npx tsc --noEmit` har feilet på `main` en stund. Feilene er ekte, men ingen av dem har krasjet appen — derfor har de fått ligge. Etter denne går typecheck rent (exit 0).

## Hva som var galt

**Fem rutestier manglet `(app)`-gruppa.** Resten av koden bruker allerede full sti (`/(app)/(modals)/qrmodal`, `/(app)/(modals)/varsler`, `/(app)/(tabs)/profil/…`), så disse var avvikerne:

| Fil | Før | Etter |
|---|---|---|
| `arrangement/[arrangementId].tsx:321` | `/(modals)/arrangement/[arrangementId]/event-register` | `/(app)/…` |
| `boter/[groupSlug]/brukere.tsx:78` | `/(modals)/boter/[groupSlug]/bekreft` | `/(app)/…` |
| `boter/[groupSlug]/index.tsx:49` | `/(modals)/boter/[groupSlug]/brukere` | `/(app)/…` |
| `arrangementer/index.tsx:238` | `/(modals)/arrangement/${id}` | `/(app)/…` |
| `karriere/index.tsx:57` | `/(tabs)/karriere/${id}` | `/(app)/…` |

**`useRefresh` hadde for smal type.** Den tok bare `string` i nøkkelen, men arrangementslista har filterflagg i sin: `["events", søk, expired, openForSignUp, userFavorite]`. Det er typen som var feil, ikke kallstedet — så den er utvidet til å tåle de delene react-query faktisk får. Ingen runtime-endring; nøkkelen har alltid inneholdt booleans.

**Resten er små:**
- `BottomSheetFlatList` utleder ikke elementtypen, så deltagerlista fikk implisitt `any` → annotert med `Registration`
- `useRef` krever eksplisitt initialverdi i React 19
- `setTimeout` gir `number` i React Native, ikke `NodeJS.Timeout`

## Verifisert

- `npx tsc --noEmit` → exit 0 (var exit 2 med 13 feil)
- `npx expo lint` → 0 errors, 4 warnings som alle finnes på `main` fra før
- Kjørt i simulator og navigert gjennom rutene som er endret:
  - ✅ event-kort → arrangementsmodal
  - ✅ jobbannonse → karrieredetaljer
  - ✅ bot-fane → velg gruppe → velg lov → velg brukere
  - ⚠️ `bekreft`-steget er **ikke** klikket gjennom — det ville gitt en ekte bot i Photon
  - ⚠️ `event-register` er ikke testet, krever admin-rettigheter

## Merk

Antall feil avhenger av om `.expo/types/router.d.ts` er generert. Uten den (fersk clone som aldri har kjørt `expo start`) faller rutestrenger tilbake til `string`, og du ser bare 7 av de 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)