### PR TITLE
fix: påmelding, pris og påmeldingsknapp på arrangementer

### DIFF
--- a/actions/events/payments.ts
+++ b/actions/events/payments.ts
@@ -1,5 +1,6 @@
 import { apiJson } from "@/lib/api/client";
 import { Payment } from "../types";
+import * as Linking from "expo-linking";
 
 /**
  * Starter betaling for et arrangement.
@@ -8,8 +9,21 @@ import { Payment } from "../types";
  * legger betalingen under arrangementet, så id-en flyttes til stien.
  */
 export async function createPayment(eventid: string) {
+    // `returnUrl` er påkrevd i Photon, og kallet gikk uten body i det hele
+    // tatt — serveren fikk Content-Type: application/json og ingenting å
+    // parse, så betaling feilet før den kom i gang.
+    //
+    // `NATIVE_REDIRECT` finnes nettopp for apper: betalingsleverandøren
+    // sender brukeren tilbake til `tihlde://arrangement/<id>` i stedet for å
+    // etterlate dem i nettleseren.
     return apiJson<Payment>(
         `/event/${encodeURIComponent(String(eventid))}/payment`,
-        { method: "POST" }
+        {
+            method: "POST",
+            body: JSON.stringify({
+                returnUrl: Linking.createURL(`/arrangement/${eventid}`),
+                userFlow: "NATIVE_REDIRECT",
+            }),
+        }
     );
 }

--- a/actions/events/registrations.ts
+++ b/actions/events/registrations.ts
@@ -41,9 +41,15 @@ export async function iAmRegisteredToEvent(eventId: string): Promise<Registratio
 }
 
 export async function registerToEvent(eventId: string): Promise<Registration> {
+    // Photon krever en JSON-body her (`requestBody.required`), og `apiFetch`
+    // setter Content-Type uansett — uten body prøvde serveren å parse tomt og
+    // svarte «Malformed JSON in request body», så påmelding var umulig.
+    //
+    // `allowPhoto` utelates med vilje: da bruker Photon samtykket brukeren har
+    // satt på kontoen sin, som er der det hører hjemme.
     const response = await apiFetch(
         `/event/${encodeURIComponent(String(eventId))}/registration`,
-        { method: "POST" }
+        { method: "POST", body: JSON.stringify({}) }
     );
 
     if (!response.ok) {

--- a/actions/photon.ts
+++ b/actions/photon.ts
@@ -203,7 +203,16 @@ export const toEvent = (
         contact_person: event.contactPerson
             ? splitName(event.contactPerson.name)
             : undefined,
-        paid_information: { price: String(event.payInfo?.price ?? "") },
+        // Photon oppgir prisen i øre («Event price in minor units»), mens
+        // skjermen viser hele kroner. Uten delingen ble 150 kr til «15000».
+        //
+        // Feltet må være undefined for gratis arrangementer: skjermen bruker
+        // `event.paid_information` som «koster dette noe?», og et objekt som
+        // alltid er satt er alltid truthy — da fikk påmeldte på gratis
+        // arrangementer betalingsvarsel.
+        paid_information: event.payInfo?.price
+            ? { price: String(Math.round(event.payInfo.price) / 100) }
+            : undefined,
         limit: event.capacity ?? 0,
         list_count: String(counts?.listCount ?? 0),
         waiting_list_count: String(counts?.waitingListCount ?? 0),

--- a/actions/types/event.ts
+++ b/actions/types/event.ts
@@ -20,7 +20,9 @@ export type Event = {
         first_name: string;
         last_name: string;
     };
-    paid_information: {
+    /** Bare satt for arrangementer som faktisk koster noe. */
+    paid_information?: {
+        /** Hele kroner. Photon oppgir øre — omregningen skjer i `toEvent`. */
         price: string;
     };
     limit: number;

--- a/actions/users/me.ts
+++ b/actions/users/me.ts
@@ -138,7 +138,7 @@ const asEvent = (registration: MyRegistration): Event =>
         title: registration.title,
         start_date: registration.startTime,
         end_date: registration.startTime,
-        paid_information: { price: "" },
+        paid_information: undefined,
         limit: 0,
         list_count: "0",
         waiting_list_count: "0",

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -308,7 +308,7 @@ export default function ArrangementSide() {
                                 <DetailRow
                                     icon={<CreditCard size={18} color={mutedColor} />}
                                     label="Pris"
-                                    value={event.data.paid_information.price}
+                                    value={formatPrice(event.data.paid_information.price)}
                                     isLast
                                 />
                             )}
@@ -798,14 +798,14 @@ function RegistrationButton({
                     <Pressable
                         onPress={() => onClick?.()}
                         disabled={isDisabled || mutationPending}
-                        className={`h-14 rounded-2xl flex-row items-center justify-center mb-2 active:opacity-80 ${
+                        className={`min-h-14 px-4 py-3 rounded-2xl flex-row items-center justify-center mb-2 active:opacity-80 ${
                             isDisabled ? 'bg-primary/40 dark:bg-primary/30' : 'bg-primary'
                         }`}
                     >
                         {mutationPending ? (
                             <ActivityIndicator color="white" />
                         ) : (
-                            <Text className="text-white text-base font-semibold" style={{ fontFamily: "Inter" }}>
+                            <Text className="text-white text-base font-semibold text-center" style={{ fontFamily: "Inter" }}>
                                 {showCountdown && countdownTime && !countdownIsForPayment ? (
                                     <CountTextWrapper
                                         interval={1000}
@@ -864,6 +864,22 @@ function PaymentButton({ eventId }: { eventId: string }) {
             )}
         </Pressable>
     );
+}
+
+/**
+ * Photon oppgir prisen i øre; `toEvent` gjør om til kroner. Her handler det
+ * bare om visningen: hele kroner uten desimaler, ører med komma slik norsk
+ * skrivemåte er — «510 kr», ikke «510.0 kr».
+ */
+function formatPrice(kroner: string): string {
+    const value = Number(kroner);
+    if (!Number.isFinite(value)) return `${kroner} kr`;
+
+    const decimals = Number.isInteger(value) ? 0 : 2;
+    return `${value.toLocaleString("no-NO", {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+    })} kr`;
 }
 
 function CountTextWrapper({
@@ -938,10 +954,26 @@ function CountTextWrapper({
     const hours = Math.floor((remaining / (1000 * 60 * 60)) % 24);
     const minutes = Math.floor((remaining / (1000 * 60)) % 60);
     const seconds = Math.floor((remaining / 1000) % 60);
+
+    // Ledd som er null tas bort. «0 timer, 0 minutter og 41 sekunder» brakk
+    // over to linjer i knappen og leste som om noe var galt — «41 sekunder»
+    // sier det samme og får plass.
+    const parts = [
+        hours > 0 && `${hours} ${hours === 1 ? "time" : "timer"}`,
+        minutes > 0 && `${minutes} ${minutes === 1 ? "minutt" : "minutter"}`,
+        seconds > 0 && `${seconds} ${seconds === 1 ? "sekund" : "sekunder"}`,
+    ].filter(Boolean) as string[];
+
+    const spelled =
+        parts.length > 1
+            ? `${parts.slice(0, -1).join(", ")} og ${parts[parts.length - 1]}`
+            : (parts[0] ?? "et øyeblikk");
+
     return (
         <Text>
             {prefix}
-            {hours} timer, {minutes} minutter og {seconds} sekunder {suffix}
+            {spelled}
+            {suffix}
         </Text>
     );
 }


### PR DESCRIPTION
Startet som «knappen ser stygg ut», endte i fire feil med felles rot i `toEvent` og `apiFetch`.

## 1. Påmelding var umulig

`registerToEvent` svarte **«Malformed JSON in request body»**. `apiFetch` setter `Content-Type: application/json` på alle kall ([client.ts:54](lib/api/client.ts:54)), men kallet sendte ingen body — så Photon prøvde å parse tomt. Spekken sier `requestBody.required: true`.

Sender `{}` nå. `allowPhoto` utelates med vilje: da bruker Photon samtykket brukeren har satt på kontoen sin, som er der det hører hjemme.

## 2. Betaling kunne aldri ha virket

`createPayment` hadde samme feil, **og** manglet `returnUrl`, som er `required` i `CreatePaymentBody`. Sender nå returnUrl som deep link tilbake til arrangementet, med `userFlow: NATIVE_REDIRECT` — som finnes nettopp for apper, så Vipps sender brukeren tilbake i appen i stedet for å etterlate dem i nettleseren.

## 3. Prisen var i øre

Photons spek, ordrett: *«Event price in minor units (øre)»*. Mappingen sendte tallet rett videre, så Immatrikuleringsball 2026 (`price: 51000`) viste **«51000»** i stedet for «510 kr». Deles nå på 100 og formateres på norsk.

## 4. Gratis arrangementer ble behandlet som betalte

`toEvent` satte alltid `paid_information`, og et objekt som alltid finnes er alltid truthy. Feltet brukes tre steder som «koster dette noe?» — så gratis arrangementer viste raden «Pris 0», og påmeldte på dem fikk betalingsvarsel ([linje 679](app/(app)/(modals)/arrangement/[arrangementId].tsx:679)). Feltet er nå `undefined` når det ikke er noe å betale.

## Og knappen

Nedtellingen skrev «0 timer, 0 minutter og 41 sekunder», som brakk over to linjer i en knapp med fast høyde. Ledd som er null tas bort («41 sekunder»), teksten er sentrert, og knappen vokser i stedet for å sprekke.

## Verifisert

| Sjekk | Status |
|---|---|
| `tsc --noEmit` | ✅ exit 0 |
| `expo lint` | ✅ 0 errors |
| Pris i simulator | ✅ «510 kr» på Immatrikuleringsballet (var «51000») |
| Gratis arrangement | ✅ «Pris 0»-raden borte på Apptest |
| Prisenhet | ✅ bekreftet mot OpenAPI-spek og ekte data |
| Body-kravet | ✅ bekreftet mot OpenAPI-spek |
| **Faktisk påmelding** | ❌ **ikke kjørt** |
| **Knappen visuelt** | ❌ **ikke sett** |

De to siste lot seg ikke teste: simulatorens HID-port døde midtveis, så skjermbilder virker men ikke trykk — den overlevde ikke full restart av CoreSimulator. Diagnosen for påmeldingen er godt begrunnet mot spekken, men **ikke bekreftet ende til ende**. Bør klikkes gjennom på enhet før den stoles på.

🤖 Generated with [Claude Code](https://claude.com/claude-code)