### PR TITLE
feat: godkjenn arrangementsreglene der påmeldingen skjer

### DIFF
--- a/actions/types/user.ts
+++ b/actions/types/user.ts
@@ -22,6 +22,8 @@ type PermissionTypes = {
     destroy?: boolean;
     update?: boolean;
     retrieve?: boolean;
+    /** Om brukeren kan melde seg på. Alumni kan lese, men ikke melde seg på. */
+    register?: boolean;
 }
 
 export type Permissions = {

--- a/actions/users/me.ts
+++ b/actions/users/me.ts
@@ -74,7 +74,7 @@ export default async function me(): Promise<User> {
  * `events:update@group:sosialen`; her holder det å vite at brukeren har den et
  * sted, siden API-et sjekker scopet på nytt når handlingen faktisk utføres.
  *
- * Appen leser bare `event.write` og `fine.write`, så oversettelsen dekker det
+ * Appen leser `event.write`, `event.register` og `fine.write`, så oversettelsen dekker det
  * den faktisk bruker framfor å gjenskape en tabell ingen spør etter. Lesing er
  * åpen for innloggede i Photon, så `read` er sann når sesjonen finnes.
  */
@@ -98,6 +98,10 @@ export async function myPermissions(): Promise<Permissions> {
                 "events:registrations:manage",
                 "events:registrations:checkin",
             ),
+            // Alumni har lesetilgang uten påmeldingsrett. Brukes til å la være
+            // å mase om arrangementsreglene på folk som uansett ikke kan melde
+            // seg på — samme avgrensning som nettsiden gjør.
+            register: has("events:registrations:create"),
         },
         fine: {
             read: true,

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -23,6 +23,8 @@ import UserCard from "@/components/ui/userCard";
 import CoverImage, { COVER_IMAGE_FRAME } from "@/components/ui/coverImage";
 import useRefresh from "@/lib/useRefresh";
 import { SectionHeader } from "@/components/ui/section-header";
+import EventRulesConsent from "@/components/events/EventRulesConsent";
+import { useEventRulesConsent } from "@/lib/useEventRulesConsent";
 import { useColorScheme } from "@/lib/useColorScheme";
 import { isBefore, isAfter } from "date-fns";
 import {
@@ -673,6 +675,8 @@ function RegistrationButton({
 
     const [buttonText, setButtonText] = useState<string>("");
 
+    const eventRules = useEventRulesConsent();
+
     const showAlert = registration || hasUnansweredEvaluations;
     const alertType =
         (registration?.is_on_wait && "info") ||
@@ -747,6 +751,12 @@ function RegistrationButton({
 
     const bannerStyle = statusBannerStyles[alertType] ?? statusBannerStyles.success;
 
+    // Samme avgrensning som nettsiden: bare tilstandene der medlemmet ellers
+    // kunne ha meldt seg på. Er man allerede påmeldt, eller har arrangementet
+    // ingen påmelding, er samtykket irrelevant her.
+    const blockedByEventRules =
+        eventRules.mustAccept && event.sign_up === true && !registration;
+
     return (
         <>
             {showAlert && (
@@ -771,7 +781,30 @@ function RegistrationButton({
 
             {showCountdown && countdownTime && countdownIsForPayment && <PaymentButton eventId={event.id} />}
 
-            {isAfter(new Date(event.end_date), new Date()) && (
+            {/*
+              * Reglene må godkjennes før Photon slipper noen på, så samtykket
+              * står der påmeldingsknappen ellers ville stått — også før
+              * påmeldingen åpner, slik at det oppdages i god tid og ikke i
+              * sekundet plassene slippes.
+              *
+              * Bare for den som ellers kunne meldt seg på: å be noen godkjenne
+              * regler på et arrangement de allerede står på, eller som ikke har
+              * påmelding i det hele tatt, hjelper ingen.
+              */}
+            {blockedByEventRules && (
+                <EventRulesConsent
+                    message={
+                        isAfter(new Date(event.start_registration_at), new Date())
+                            ? "Gjør det nå, så er du klar når påmeldingen åpner."
+                            : "Huk av, så kan du melde deg på med én gang."
+                    }
+                    onAccept={eventRules.acceptEventRules}
+                    isSubmitting={eventRules.isSubmitting}
+                    error={eventRules.error}
+                />
+            )}
+
+            {isAfter(new Date(event.end_date), new Date()) && !blockedByEventRules && (
                 isDestructive ? (
                     /* Unregister button — matches profile logout style */
                     <Pressable

--- a/components/events/EventRulesConsent.tsx
+++ b/components/events/EventRulesConsent.tsx
@@ -1,0 +1,78 @@
+import { ActivityIndicator, Pressable, View } from "react-native";
+import * as WebBrowser from "expo-web-browser";
+
+import { Text } from "@/components/ui/text";
+import { Switch } from "@/components/ui/switch";
+import { ScrollText } from "lucide-react-native";
+import { EVENT_RULES_URL } from "@/lib/useEventRulesConsent";
+import { themeColors } from "@/lib/theme/colors";
+import { useColorScheme } from "@/lib/useColorScheme";
+
+type Props = {
+    /** Kalles når medlemmet godtar. Én handling — det finnes ingen angre her. */
+    onAccept: () => void;
+    isSubmitting?: boolean;
+    error?: string | null;
+    /** Linja under tittelen, som avhenger av om påmeldingen har åpnet. */
+    message: string;
+};
+
+/**
+ * Blokkeringen medlemmer ellers møter for sent: reglene må godkjennes før
+ * Photon slipper deg på et arrangement, men bryteren lå bare i
+ * profilinnstillingene. Her kan de godkjenne der de står.
+ *
+ * Nettsiden bruker en avkryssingsboks. Appen har ingen, og profilsiden har
+ * allerede en bryter for det samme valget — så den brukes her, slik at det er
+ * samme kontroll begge steder.
+ */
+export default function EventRulesConsent({
+    onAccept,
+    isSubmitting,
+    error,
+    message,
+}: Props) {
+    const { isDarkColorScheme } = useColorScheme();
+    const palette = themeColors(isDarkColorScheme);
+
+    return (
+        <View className="rounded-2xl bg-muted/60 dark:bg-muted/30 px-4 py-4 mb-3">
+            <View className="flex-row items-center">
+                <ScrollText size={18} color={palette.foreground} />
+                <Text className="flex-1 text-base font-semibold text-foreground ml-2.5">
+                    Du må godkjenne arrangementsreglene
+                </Text>
+            </View>
+
+            <Text className="text-sm text-muted-foreground mt-2">{message}</Text>
+
+            <View className="flex-row items-center mt-4">
+                <Switch
+                    checked={false}
+                    disabled={isSubmitting}
+                    onCheckedChange={(checked) => {
+                        if (checked) onAccept();
+                    }}
+                    nativeID="event-rules-consent"
+                />
+                <Text className="flex-1 text-sm text-foreground ml-3">
+                    Jeg har lest og godtar arrangementsreglene
+                </Text>
+                {isSubmitting ? <ActivityIndicator size="small" /> : null}
+            </View>
+
+            {error ? (
+                <Text className="text-sm text-destructive mt-3">{error}</Text>
+            ) : null}
+
+            <Pressable
+                onPress={() => WebBrowser.openBrowserAsync(EVENT_RULES_URL)}
+                className="h-11 rounded-xl border border-border items-center justify-center mt-4 active:opacity-70"
+            >
+                <Text className="text-sm font-semibold text-foreground">
+                    Les reglene
+                </Text>
+            </Pressable>
+        </View>
+    );
+}

--- a/lib/useEventRulesConsent.ts
+++ b/lib/useEventRulesConsent.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { mySettings, settingsKeys, updateMySettings } from "@/actions/users/settings";
+import { usePermissions } from "@/actions/users/me";
+
+export const EVENT_RULES_URL = "https://wiki.tihlde.org/arrangementer";
+
+/**
+ * Om medlemmet mangler godkjenning av arrangementsreglene, og handlingen som
+ * fikser det.
+ *
+ * Photon avviser påmelding uten godkjenning. Fram til nå lå bryteren bare i
+ * profilinnstillingene, så den som ikke hadde huket av ble avvist på
+ * arrangementssiden uten å få vite hvorfor. Nettsiden viser samtykket der
+ * påmeldingen skjer — og før påmeldingen åpner, som er hele poenget: de skal
+ * oppdage det i god tid, ikke i sekundet plassene slippes.
+ */
+export function useEventRulesConsent() {
+    const queryClient = useQueryClient();
+
+    const settings = useQuery({
+        queryKey: settingsKeys.mine,
+        queryFn: mySettings,
+    });
+
+    // Den som ikke kan melde seg på har ingen nytte av varselet — de stoppes
+    // uansett et annet sted. Alumni er tilfellet dette gjelder.
+    const permissions = usePermissions();
+    const canRegister = permissions.data?.event?.register ?? true;
+
+    const accept = useMutation({
+        mutationFn: () => updateMySettings({ acceptsEventRules: true }),
+        onSuccess: (updated) => {
+            // Godkjenningen ligger i innstillingene, så de må oppdateres for at
+            // påmeldingsknappen skal dukke opp uten at skjermen lastes på nytt.
+            queryClient.setQueryData(settingsKeys.mine, updated);
+        },
+    });
+
+    return {
+        mustAccept:
+            settings.isSuccess &&
+            canRegister &&
+            settings.data.acceptsEventRules !== true,
+        isSubmitting: accept.isPending,
+        error: accept.error ? "Kunne ikke lagre godkjenningen. Prøv igjen." : null,
+        acceptEventRules: () => accept.mutate(),
+    };
+}


### PR DESCRIPTION
Første steg mot at påmeldingsflyten i appen ligner nettsidas.

## Hvorfor

Photon avviser påmelding uten godkjente arrangementsregler — [`use-event-rules-consent.ts`](https://github.com/TIHLDE/Photon) sier det rett ut: *«API-et avviser påmelding uten godkjenning»*. I appen lå bryteren bare i profilinnstillingene, så den som ikke hadde huket av ble avvist på arrangementssiden uten å få vite hvorfor.

Nettsiden viser samtykket i påmeldingskortet, **også før påmeldingen åpner** — som er hele poenget: det skal oppdages i god tid, ikke i sekundet plassene slippes.

## Hva som er gjort

- `lib/useEventRulesConsent.ts` — leser innstillingene, avgjør `mustAccept`, og lagrer godkjenningen. Speiler nettsidas hook.
- `components/events/EventRulesConsent.tsx` — samtykket, vist der påmeldingsknappen ellers står.
- `event.register` lagt til i rettighetene mot scopet `events:registrations:create`, så alumni slipper å bli mast på om regler de uansett ikke får bruk for. Samme avgrensning som nettsiden.

Meldinga følger nettsidas to varianter: *«Gjør det nå, så er du klar når påmeldingen åpner»* før åpning, *«Huk av, så kan du melde deg på med én gang»* etterpå.

## To bevisste avvik fra nettsiden

1. **Bryter i stedet for avkryssingsboks.** Appen har ingen checkbox-primitiv, og profilsiden har allerede en bryter for nøyaktig samme valg — så det er samme kontroll begge steder.
2. **Ingen global banner.** Nettsiden viser samtykket app-bredt i `_app.tsx` i tillegg til på arrangementet. Det er utelatt her; en permanent banner over alle faner er mer påtrengende på mobil. Lett å legge til om dere vil ha det.

## Verifisert

| Sjekk | Status |
|---|---|
| `tsc --noEmit` | ✅ exit 0 |
| `expo lint` | ✅ 0 errors (4 warnings, alle fra før) |
| Komponenten rendrer | ✅ se skjermbilde i PR-tråden |
| Arrangementssida ellers | ✅ ingen regresjon, pris viser fortsatt «510 kr» |
| **Selve godkjenningen (PATCH)** | ❌ **ikke kjørt** |
| **Gatingen i praksis** | ❌ **ikke sett** |

Simulatorens HID-port er død på maskinen min — skjermbilder virker, men ikke trykk, og den overlevde ikke full restart av CoreSimulator. Komponenten ble derfor sett ved å rendre den midlertidig øverst på sida; **plasseringen og gatingen er ikke observert i drift**, bare lest. Bør klikkes gjennom på enhet.

## Gjenstår for full likhet med nettsiden

Venteliste som egen handling, betalingsfrist som nedtelling, `hasPaid` som skjuler avmelding, videresalg av billett, `notEligibleReason`, og feilmelding fra siste forsøk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)