### PR TITLE
feat: påmeldingskortet følger nettsidas tilstandsmaskin

### DIFF
--- a/actions/events/events.ts
+++ b/actions/events/events.ts
@@ -1,5 +1,6 @@
-import { apiJson } from "@/lib/api/client";
+import { apiFetch, apiJson } from "@/lib/api/client";
 import { API_URL } from "@/actions/constant";
+import { getToken } from "@/lib/storage/tokenStore";
 import { Event, JobPost } from "../types";
 import { PhotonEvent, toEvent, toJobTypeKey } from "@/actions/photon";
 
@@ -81,8 +82,21 @@ export async function fetchFavoriteEvents(options: {
     return { results, next: null };
 }
 
+/**
+ * Ett arrangement.
+ *
+ * Åpent endepunkt, så det virker uten token — men Photon legger innloggedes
+ * egen påmelding på arrangementet, og bare når kallet er autentisert. Uten
+ * token er `registration` alltid borte, og skjermen vet ikke om du står på
+ * lista. Derfor: token når vi har en, vanlig fetch ellers.
+ */
 export async function fetchEvent(eventId: string): Promise<Event> {
-    const response = await fetch(`${API_URL}/event/${encodeURIComponent(eventId)}`);
+    const path = `/event/${encodeURIComponent(eventId)}`;
+    const token = await getToken();
+
+    const response = token
+        ? await apiFetch(path)
+        : await fetch(`${API_URL}${path}`);
 
     if (!response.ok) {
         throw new Error(`Kunne ikke hente arrangementet (${response.status})`);

--- a/actions/photon.ts
+++ b/actions/photon.ts
@@ -18,6 +18,7 @@ import type {
     Law,
     Membership,
     Notification,
+    Registration,
     User,
     UserSettings,
 } from "@/actions/types";
@@ -177,7 +178,58 @@ export type PhotonEvent = {
     organizer?: { name: string; slug: string } | null;
     contactPerson?: { name?: string | null } | null;
     payInfo?: { price?: number | null } | null;
+    closed?: boolean;
+    allowWaitlist?: boolean;
+    isPaidEvent?: boolean;
+    registeredCount?: number | null;
+    waitlistCount?: number | null;
+    /**
+     * Innloggedes egen påmelding. Photon legger den på arrangementet, og bare
+     * for den som spør — så den finnes kun når kallet har token.
+     *
+     * Dette er den eneste kilden som gir både status, ventelisteplass og
+     * betalingsfrist. Påmeldingslista gir det bare til arrangementsadmin.
+     */
+    registration?: PhotonOwnRegistration | null;
 };
+
+export type PhotonOwnRegistration = {
+    status:
+        | "registered"
+        | "waitlisted"
+        | "cancelled"
+        | "attended"
+        | "no_show"
+        | "pending";
+    waitlistPosition?: number | null;
+    attendedAt?: string | null;
+    hasPaid?: boolean;
+    paymentExpiresAt?: string | null;
+    createdAt?: string;
+    updatedAt?: string;
+};
+
+/**
+ * Innloggedes egen påmelding, hentet fra arrangementet.
+ *
+ * Skjermen ba tidligere om påmeldingslista og lette etter seg selv på e-post.
+ * Photon oppgir bare e-post til arrangementsadmin, så for vanlige medlemmer
+ * fant den aldri noe — appen trodde ingen var påmeldt.
+ */
+export const toOwnRegistration = (
+    registration: PhotonOwnRegistration,
+): Registration =>
+    ({
+        has_attended: registration.attendedAt != null,
+        has_paid_order: registration.hasPaid === true,
+        has_unanswered_evaluation: false,
+        is_on_wait: registration.status === "waitlisted",
+        payment_expiredate: registration.paymentExpiresAt ?? "",
+        payment_orders: [],
+        wait_queue_number: registration.waitlistPosition ?? 0,
+        registration_id: 0,
+        status: registration.status,
+    }) as unknown as Registration;
 
 /**
  * Photon holder ikke påmeldingstall på arrangementet slik Lepton gjorde.
@@ -213,9 +265,20 @@ export const toEvent = (
         paid_information: event.payInfo?.price
             ? { price: String(Math.round(event.payInfo.price) / 100) }
             : undefined,
+        closed: event.closed ?? false,
+        allow_waitlist: event.allowWaitlist ?? false,
+        is_paid_event: event.isPaidEvent ?? Boolean(event.payInfo?.price),
+        my_registration: event.registration
+            ? toOwnRegistration(event.registration)
+            : undefined,
         limit: event.capacity ?? 0,
-        list_count: String(counts?.listCount ?? 0),
-        waiting_list_count: String(counts?.waitingListCount ?? 0),
+        // Photon legger tallene på arrangementet. `counts` er igjen fra da de
+        // måtte hentes fra påmeldingslista, og brukes fortsatt når kalleren har
+        // dem — men arrangementet er kilden når det svarer.
+        list_count: String(event.registeredCount ?? counts?.listCount ?? 0),
+        waiting_list_count: String(
+            event.waitlistCount ?? counts?.waitingListCount ?? 0,
+        ),
         sign_off_deadline: event.cancellationDeadline ?? "",
         end_registration_at: event.registrationEnd ?? "",
         start_registration_at: event.registrationStart ?? "",

--- a/actions/types/event.ts
+++ b/actions/types/event.ts
@@ -1,3 +1,4 @@
+import type { Registration } from "./registration";
 
 export type Event = {
     // Photon bruker UUID der Lepton hadde løpenummer.
@@ -26,6 +27,13 @@ export type Event = {
         price: string;
     };
     limit: number;
+    /** Arrangøren har stengt påmeldingen manuelt. */
+    closed?: boolean;
+    /** Om fulle arrangementer har venteliste. Uten den er fullt endestasjon. */
+    allow_waitlist?: boolean;
+    is_paid_event?: boolean;
+    /** Innloggedes egen påmelding. Bare satt når kallet hadde token. */
+    my_registration?: Registration;
     list_count: string;
     waiting_list_count: string;
     sign_off_deadline: string;

--- a/actions/types/registration.ts
+++ b/actions/types/registration.ts
@@ -9,5 +9,13 @@ export type Registration = {
     payment_orders: string[];
     wait_queue_number: number;
     registration_id: number;
+    /** Photons egen status. Avgjør hvilken tilstand påmeldingskortet viser. */
+    status?:
+        | "registered"
+        | "waitlisted"
+        | "cancelled"
+        | "attended"
+        | "no_show"
+        | "pending";
     user_info: User;
 }

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -8,11 +8,11 @@ import PageWrapper from "@/components/ui/pagewrapper";
 import { fetchEvent, fetchEventCounts } from "@/actions/events/events";
 import { iAmRegisteredToEvent, registerToEvent, unregisterFromEvent } from "@/actions/events/registrations";
 import { Event, Registration } from "@/actions/types";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import useInterval from "@/lib/useInterval";
 import { createPayment } from "@/actions/events/payments";
 import * as WebBrowser from "expo-web-browser";
-import me, { usePermissions } from "@/actions/users/me";
+import { usePermissions } from "@/actions/users/me";
 import Toast from "react-native-toast-message";
 import Icon from "@/lib/icons/Icon";
 import { GestureHandlerRootView, ScrollView } from "react-native-gesture-handler";
@@ -24,9 +24,16 @@ import CoverImage, { COVER_IMAGE_FRAME } from "@/components/ui/coverImage";
 import useRefresh from "@/lib/useRefresh";
 import { SectionHeader } from "@/components/ui/section-header";
 import EventRulesConsent from "@/components/events/EventRulesConsent";
+import {
+    TICKET_RESALE_GROUP_URL,
+    deriveRegistrationState,
+    formatCountdown,
+    formatTimeUntil,
+    registrationErrorMessage,
+} from "@/lib/events/registrationState";
 import { useEventRulesConsent } from "@/lib/useEventRulesConsent";
 import { useColorScheme } from "@/lib/useColorScheme";
-import { isBefore, isAfter } from "date-fns";
+import { isBefore } from "date-fns";
 import {
     CalendarDays,
     Clock,
@@ -42,7 +49,26 @@ import {
     TriangleAlert,
     Info,
     OctagonX,
+    Ticket,
 } from "lucide-react-native";
+
+/**
+ * Datoformatene skjermen bruker. Lå tidligere inne i sidekomponenten, men
+ * påmeldingskortet trenger dem også — det viser når påmeldingen åpner og når
+ * betalingsfristen går ut.
+ */
+const formatDate = (dateStr: string) =>
+    new Date(dateStr).toLocaleDateString("no-NO", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    });
+
+const formatTime = (dateStr: string) =>
+    new Date(dateStr).toLocaleTimeString("no-NO", {
+        hour: "2-digit",
+        minute: "2-digit",
+    });
 
 function DetailRow({
     icon,
@@ -236,18 +262,6 @@ export default function ArrangementSide() {
 
     const hasSignOffDeadline = isValidDate(event.data.sign_off_deadline);
 
-    const formatDate = (dateStr: string) =>
-        new Date(dateStr).toLocaleDateString("no-NO", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-        });
-
-    const formatTime = (dateStr: string) =>
-        new Date(dateStr).toLocaleTimeString("no-NO", {
-            hour: "2-digit",
-            minute: "2-digit",
-        });
 
     return (
         <GestureHandlerRootView style={{ flex: 1 }}>
@@ -370,6 +384,7 @@ export default function ArrangementSide() {
                                     registration={registration}
                                     registrationPending={registrationPending}
                                     mutationPending={registrationMutation.isPending}
+                                    mutationError={registrationMutation.error}
                                     onClick={() => registrationMutation.mutate(String(id))}
                                     unregisterSheetRef={unregisterSheetRef}
                                 />
@@ -634,12 +649,21 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
     );
 }
 
+/**
+ * Påmeldingskortet.
+ *
+ * Bygger på tilstandsmaskinen i `lib/events/registrationState`, som er portert
+ * fra nettsida. Tidligere sto det en håndfull løse booleans her, og de dekket
+ * verken venteliste, betaling eller en påmelding som fortsatt behandles — så
+ * appen sa noe annet enn nettsida om det samme arrangementet.
+ */
 function RegistrationButton({
     event,
     registration,
     registrationPending,
     onClick,
     mutationPending,
+    mutationError,
     unregisterSheetRef,
 }: {
     event: Event;
@@ -647,154 +671,137 @@ function RegistrationButton({
     registrationPending?: boolean;
     onClick?: () => void;
     mutationPending?: boolean;
+    mutationError?: unknown;
     unregisterSheetRef: React.RefObject<BottomSheetModal | null>;
 }) {
     const { isDarkColorScheme } = useColorScheme();
-    const user = useQuery({
-        queryKey: ["users", "me"],
-        queryFn: me,
-    });
-
-    const hasUnansweredEvaluations = user.data?.unanswered_evaluations_count !== 0;
-    const [isDisabled, setIsDisabled] = useState<boolean>();
-    const isDestructive = registration;
-
-    const getButtonText = (event: Event) => {
-        if (isBefore(new Date(event.end_registration_at), new Date()) && !registration) {
-            return "Påmeldingsfrist utløpt";
-        }
-        if (registration) {
-            return "Meld deg av arrangementet";
-        }
-        const waitingList = Number(event.waiting_list_count);
-        if (waitingList > 0) {
-            return `Meld deg på plass ${waitingList + 1} i ventelisten`;
-        }
-        return "Meld deg på arrangementet";
-    };
-
-    const [buttonText, setButtonText] = useState<string>("");
-
+    const palette = themeColors(isDarkColorScheme);
     const eventRules = useEventRulesConsent();
 
-    const showAlert = registration || hasUnansweredEvaluations;
-    const alertType =
-        (registration?.is_on_wait && "info") ||
-        (event.paid_information && !registration?.has_paid_order && registration && "warning") ||
-        (hasUnansweredEvaluations && "error") ||
-        "success";
+    // Nedtellingene løper mens skjermen står åpen, så tilstanden må regnes fra
+    // en klokke som tikker — ikke fra tidspunktet komponenten ble tegnet.
+    const [now, setNow] = useState<Date>(() => new Date());
+    useInterval(() => setNow(new Date()), 1000);
 
-    const getAlertMessage = () => {
-        if (registration?.is_on_wait) {
-            return `Du er på plass ${registration.wait_queue_number} av ${event.waiting_list_count} på ventelisten. Vi gir deg beskjed om du får plass.`;
-        }
-        if (hasUnansweredEvaluations && user.data?.unanswered_evaluations_count) {
-            return `Du må svare på ${user.data?.unanswered_evaluations_count > 1 ? user.data?.unanswered_evaluations_count : "ett"
-                } evalueringsskjema${user.data?.unanswered_evaluations_count > 1 ? "er" : ""} før du kan melde deg på flere arrangementer. Du finner dine ubesvarte evalueringsskjemaer under "Spørreskjemaer" på profilsiden.`;
-        }
-        if (isBefore(new Date(event.start_date), new Date())) {
-            return "Du har deltatt på arrangementet!";
-        }
-        return "Du er påmeldt arrangementet.";
-    };
+    // Photon legger egen påmelding på arrangementet. `registration` er igjen
+    // fra da den måtte letes opp i påmeldingslista, og brukes som reserve.
+    const mine = event.my_registration ?? registration ?? null;
+    const state = deriveRegistrationState(event, mine, now);
 
-    const alertMessage = getAlertMessage();
+    // Bare tilstandene der medlemmet ellers kunne meldt seg på — å be noen
+    // godkjenne regler på et stengt arrangement hjelper ingen.
+    const blockedByEventRules =
+        eventRules.mustAccept &&
+        (state === "open" || state === "not-open" || state === "full");
 
-    const countdownIsForPayment = event.paid_information && !registration?.has_paid_order && registration;
-    const countdownTime =
-        (isAfter(new Date(event.start_registration_at), new Date()) && new Date(event.start_registration_at)) ||
-        (event.paid_information &&
-            registration?.payment_expiredate &&
-            isAfter(new Date(registration.payment_expiredate), new Date()) &&
-            new Date(registration.payment_expiredate));
-
-    const [showCountdown, setShowCountdown] = useState<boolean>();
-
-    useEffect(() => {
-        setIsDisabled(
-            (isBefore(new Date(event.end_registration_at), new Date()) && !registration) ||
-            isAfter(new Date(event.start_registration_at), new Date()) ||
-            registration?.has_paid_order ||
-            mutationPending ||
-            user.data?.unanswered_evaluations_count === undefined ||
-            user.data.unanswered_evaluations_count > 0 ||
-            !event.sign_up ||
-            false
-        );
-        if (countdownTime) {
-            setShowCountdown(true);
-        }
-        setButtonText(getButtonText(event));
-    }, [event, registration, user]);
-
-    if (user.isPending || registrationPending) {
+    if (registrationPending) {
         return (
             <View className="h-14 bg-muted dark:bg-secondary/40 rounded-2xl animate-pulse mb-2" />
         );
     }
 
-    const palette = themeColors(isDarkColorScheme);
+    const errorText = mutationError
+        ? registrationErrorMessage(mutationError)
+        : null;
 
-    const statusBannerStyles: Record<string, { bg: string; iconColor: string; textColor: string }> = {
-        success: { bg: 'bg-primary/10 dark:bg-primary/20', iconColor: palette.primary, textColor: 'text-primary' },
-        info: { bg: 'bg-orange-100 dark:bg-orange-500/20', iconColor: '#ea580c', textColor: 'text-orange-600 dark:text-orange-400' },
-        warning: { bg: 'bg-orange-100 dark:bg-orange-500/20', iconColor: '#ea580c', textColor: 'text-orange-600 dark:text-orange-400' },
-        error: { bg: 'bg-destructive/10 dark:bg-destructive/20', iconColor: palette.destructive, textColor: 'text-destructive' },
-    };
-
-    const statusIcon: Record<string, React.ReactNode> = {
-        success: <CircleCheck size={18} color={statusBannerStyles.success.iconColor} />,
-        info: <Info size={18} color={statusBannerStyles.info.iconColor} />,
-        warning: <TriangleAlert size={18} color={statusBannerStyles.warning.iconColor} />,
-        error: <OctagonX size={18} color={statusBannerStyles.error.iconColor} />,
-    };
-
-    const bannerStyle = statusBannerStyles[alertType] ?? statusBannerStyles.success;
-
-    // Samme avgrensning som nettsiden: bare tilstandene der medlemmet ellers
-    // kunne ha meldt seg på. Er man allerede påmeldt, eller har arrangementet
-    // ingen påmelding, er samtykket irrelevant her.
-    const blockedByEventRules =
-        eventRules.mustAccept && event.sign_up === true && !registration;
+    const paymentCountdown = mine?.payment_expiredate
+        ? formatCountdown(mine.payment_expiredate, now)
+        : undefined;
 
     return (
         <>
-            {showAlert && (
-                <View className={`flex-row items-center px-4 py-3.5 rounded-2xl mb-4 ${bannerStyle.bg}`}>
-                    {statusIcon[alertType]}
-                    <View className="ml-3 flex-1">
-                        <Text className={`text-sm ${bannerStyle.textColor}`}>
-                            {showCountdown && countdownTime && countdownIsForPayment ? (
-                                <CountTextWrapper
-                                    interval={1000}
-                                    prefix="Du er påmeldt, men har "
-                                    suffix=" på å betale for å beholde plassen."
-                                    startCount={new Date(countdownTime.getTime() - Date.now())}
-                                />
-                            ) : (
-                                alertMessage
-                            )}
-                        </Text>
-                    </View>
-                </View>
+            {state === "no-signup" && (
+                <StatusBanner
+                    tone="info"
+                    palette={palette}
+                    message="Dette arrangementet har ikke påmelding"
+                    secondary="Bare møt opp."
+                />
             )}
 
-            {showCountdown && countdownTime && countdownIsForPayment && <PaymentButton eventId={event.id} />}
+            {state === "processing" && (
+                <StatusBanner
+                    tone="info"
+                    palette={palette}
+                    message="Behandler påmeldingen din …"
+                    secondary="Vi gir deg beskjed så snart plassen er klar."
+                />
+            )}
+
+            {state === "not-open" && (
+                <StatusBanner
+                    tone="info"
+                    palette={palette}
+                    message={`Påmelding åpner om ${formatTimeUntil(event.start_registration_at, now)}`}
+                    secondary={`${formatDate(event.start_registration_at)} kl. ${formatTime(event.start_registration_at)}.`}
+                />
+            )}
+
+            {state === "closed" && (
+                <StatusBanner
+                    tone="error"
+                    palette={palette}
+                    message="Påmelding er stengt"
+                />
+            )}
+
+            {state === "joined" && (
+                <StatusBanner
+                    tone="success"
+                    palette={palette}
+                    message="Du har plass på arrangementet!"
+                    secondary={
+                        mine?.has_paid_order
+                            ? "Du har betalt, så plassen kan ikke meldes av."
+                            : undefined
+                    }
+                />
+            )}
+
+            {state === "on-waitlist" && (
+                <StatusBanner
+                    tone="warning"
+                    palette={palette}
+                    message="Du er på venteliste"
+                    secondary={
+                        mine?.wait_queue_number
+                            ? `Posisjon ${mine.wait_queue_number}. Du får plassen om noen melder seg av.`
+                            : "Du får plassen om noen melder seg av."
+                    }
+                />
+            )}
+
+            {state === "awaiting-payment" && (
+                <StatusBanner
+                    tone="warning"
+                    palette={palette}
+                    message="Plass reservert — venter på betaling"
+                    secondary={paymentDeadlineText(mine, paymentCountdown)}
+                />
+            )}
+
+            {state === "full" && (
+                <StatusBanner
+                    tone="warning"
+                    palette={palette}
+                    message="Arrangementet er fullt"
+                    secondary={
+                        Number(event.waiting_list_count) > 0
+                            ? `${event.waiting_list_count} står på venteliste.`
+                            : "Meld deg på ventelista, så får du plassen om noen melder seg av."
+                    }
+                />
+            )}
 
             {/*
               * Reglene må godkjennes før Photon slipper noen på, så samtykket
               * står der påmeldingsknappen ellers ville stått — også før
-              * påmeldingen åpner, slik at det oppdages i god tid og ikke i
-              * sekundet plassene slippes.
-              *
-              * Bare for den som ellers kunne meldt seg på: å be noen godkjenne
-              * regler på et arrangement de allerede står på, eller som ikke har
-              * påmelding i det hele tatt, hjelper ingen.
+              * påmeldingen åpner, slik at det oppdages i god tid.
               */}
             {blockedByEventRules && (
                 <EventRulesConsent
                     message={
-                        isAfter(new Date(event.start_registration_at), new Date())
+                        state === "not-open"
                             ? "Gjør det nå, så er du klar når påmeldingen åpner."
                             : "Huk av, så kan du melde deg på med én gang."
                     }
@@ -804,64 +811,159 @@ function RegistrationButton({
                 />
             )}
 
-            {isAfter(new Date(event.end_date), new Date()) && !blockedByEventRules && (
-                isDestructive ? (
-                    /* Unregister button — matches profile logout style */
+            {/* Betaling: knappen hører til den reserverte plassen. */}
+            {state === "awaiting-payment" && <PaymentButton eventId={event.id} />}
+
+            {/* Påmelding, og venteliste — som går gjennom samme kall. */}
+            {(state === "open" || state === "full") && !blockedByEventRules && (
+                <Pressable
+                    onPress={() => onClick?.()}
+                    disabled={mutationPending}
+                    className={`min-h-14 px-4 py-3 rounded-2xl flex-row items-center justify-center mb-2 active:opacity-80 ${
+                        mutationPending ? "bg-primary/40 dark:bg-primary/30" : "bg-primary"
+                    }`}
+                >
+                    {mutationPending ? (
+                        <ActivityIndicator color="white" />
+                    ) : (
+                        <Text
+                            className="text-white text-base font-semibold text-center"
+                            style={{ fontFamily: "Inter" }}
+                        >
+                            {state === "full"
+                                ? "Meld deg på ventelista"
+                                : "Meld deg på arrangementet"}
+                        </Text>
+                    )}
+                </Pressable>
+            )}
+
+            {/* Billetten kan ikke gis fra seg — den selges videre. */}
+            {state === "joined" && mine?.has_paid_order && (
+                <Pressable
+                    onPress={() => WebBrowser.openBrowserAsync(TICKET_RESALE_GROUP_URL)}
+                    className="h-14 rounded-2xl flex-row items-center justify-center mb-2 border border-border active:opacity-70"
+                >
+                    <Ticket size={18} color={palette.foreground} />
+                    <Text
+                        className="text-base font-semibold text-foreground ml-2"
+                        style={{ fontFamily: "Inter" }}
+                    >
+                        Selg billetten din
+                    </Text>
+                </Pressable>
+            )}
+
+            {/*
+              * Avmelding. En betalt plass kan ikke meldes av — Photon avviser
+              * det, og knappen ville bare gitt en avvisning tilbake.
+              */}
+            {(state === "joined" || state === "on-waitlist" || state === "awaiting-payment") &&
+                !mine?.has_paid_order && (
                     <Pressable
                         onPress={() => unregisterSheetRef.current?.present()}
-                        disabled={isDisabled || mutationPending}
-                        className={`h-14 rounded-2xl flex-row items-center justify-center mb-2 active:opacity-70 ${
-                            isDisabled ? 'bg-destructive/5 dark:bg-destructive/10' : 'bg-destructive/10 dark:bg-destructive/20'
-                        }`}
+                        disabled={mutationPending}
+                        className="h-14 rounded-2xl flex-row items-center justify-center mb-2 active:opacity-70 bg-destructive/10 dark:bg-destructive/20"
                     >
                         {mutationPending ? (
                             <ActivityIndicator />
                         ) : (
                             <>
-                                {/* 80 = 50 % opacity, samme dempning som teksten ved siden av. */}
-                                <LogOut size={18} color={isDisabled ? `${palette.destructive}80` : palette.destructive} />
-                                <Text className={`text-base font-semibold ml-2 ${isDisabled ? 'text-destructive/50' : 'text-destructive'}`} style={{ fontFamily: "Inter" }}>
-                                    {buttonText}
+                                <LogOut size={18} color={palette.destructive} />
+                                <Text
+                                    className="text-base font-semibold ml-2 text-destructive"
+                                    style={{ fontFamily: "Inter" }}
+                                >
+                                    {state === "on-waitlist"
+                                        ? "Meld deg av ventelista"
+                                        : "Meld deg av arrangementet"}
                                 </Text>
                             </>
                         )}
                     </Pressable>
-                ) : (
-                    /* Register button */
-                    <Pressable
-                        onPress={() => onClick?.()}
-                        disabled={isDisabled || mutationPending}
-                        className={`min-h-14 px-4 py-3 rounded-2xl flex-row items-center justify-center mb-2 active:opacity-80 ${
-                            isDisabled ? 'bg-primary/40 dark:bg-primary/30' : 'bg-primary'
-                        }`}
-                    >
-                        {mutationPending ? (
-                            <ActivityIndicator color="white" />
-                        ) : (
-                            <Text className="text-white text-base font-semibold text-center" style={{ fontFamily: "Inter" }}>
-                                {showCountdown && countdownTime && !countdownIsForPayment ? (
-                                    <CountTextWrapper
-                                        interval={1000}
-                                        prefix="Påmelding åpner om "
-                                        suffix=""
-                                        startCount={new Date(countdownTime.getTime() - Date.now())}
-                                        onCountdownFinished={() => {
-                                            setShowCountdown(false);
-                                            setIsDisabled(false);
-                                            setButtonText("Meld deg på arrangementet");
-                                        }}
-                                    />
-                                ) : (
-                                    buttonText
-                                )}
-                            </Text>
-                        )}
-                    </Pressable>
-                )
+                )}
+
+            {/*
+              * Uten denne så knappen ut til å ikke gjøre noe når Photon avviste
+              * påmeldingen. Her havner også avvisningene som forteller at
+              * arrangementet ikke er for deg.
+              */}
+            {errorText && (
+                <View className="flex-row items-start px-4 py-3.5 rounded-2xl mb-2 bg-destructive/10 dark:bg-destructive/20">
+                    <OctagonX size={18} color={palette.destructive} />
+                    <Text className="flex-1 text-sm text-destructive ml-3">
+                        {errorText}
+                    </Text>
+                </View>
             )}
         </>
     );
 }
+
+/** Uten frist står plassen til arrangøren rydder opp. Da er det riktigere å si
+ *  ingenting enn å dikte opp en frist. */
+function paymentDeadlineText(
+    registration: Registration | null,
+    countdown: string | null | undefined,
+): string | undefined {
+    if (!registration?.payment_expiredate) return undefined;
+    // Nedtellingen kan ha passert fristen før serveren har rukket å gi plassen
+    // videre. «Betal innen 0 sekunder» er da feil — plassen er ute av
+    // medlemmets hender, og det eneste ærlige er å si det.
+    if (countdown === null) {
+        return "Betalingsfristen er gått ut. Plassen kan ha gått videre til neste på ventelista.";
+    }
+    if (!countdown) return undefined;
+    return `${countdown} igjen å betale (innen kl. ${formatTime(registration.payment_expiredate)}), ellers gis plassen videre.`;
+}
+
+const BANNER_TONES = {
+    success: { bg: "bg-primary/10 dark:bg-primary/20", text: "text-primary" },
+    info: { bg: "bg-muted/60 dark:bg-muted/30", text: "text-foreground" },
+    warning: {
+        bg: "bg-orange-100 dark:bg-orange-500/20",
+        text: "text-orange-600 dark:text-orange-400",
+    },
+    error: {
+        bg: "bg-destructive/10 dark:bg-destructive/20",
+        text: "text-destructive",
+    },
+} as const;
+
+function StatusBanner({
+    tone,
+    palette,
+    message,
+    secondary,
+}: {
+    tone: keyof typeof BANNER_TONES;
+    palette: ReturnType<typeof themeColors>;
+    message: string;
+    secondary?: string;
+}) {
+    const styles = BANNER_TONES[tone];
+    const icon = {
+        success: <CircleCheck size={18} color={palette.primary} />,
+        info: <Info size={18} color={palette.foreground} />,
+        warning: <TriangleAlert size={18} color="#ea580c" />,
+        error: <OctagonX size={18} color={palette.destructive} />,
+    }[tone];
+
+    return (
+        <View className={`flex-row items-start px-4 py-3.5 rounded-2xl mb-4 ${styles.bg}`}>
+            {icon}
+            <View className="ml-3 flex-1">
+                <Text className={`text-sm font-semibold ${styles.text}`}>{message}</Text>
+                {secondary ? (
+                    <Text className={`text-sm mt-1 ${styles.text} opacity-80`}>
+                        {secondary}
+                    </Text>
+                ) : null}
+            </View>
+        </View>
+    );
+}
+
 
 function PaymentButton({ eventId }: { eventId: string }) {
     const queryClient = useQueryClient();
@@ -913,100 +1015,4 @@ function formatPrice(kroner: string): string {
         minimumFractionDigits: decimals,
         maximumFractionDigits: decimals,
     })} kr`;
-}
-
-function CountTextWrapper({
-    interval,
-    prefix,
-    suffix,
-    startCount,
-    onCountdownFinished,
-}: {
-    interval: number;
-    prefix: string;
-    suffix: string;
-    startCount: Date;
-    onCountdownFinished?: () => void;
-}) {
-    const [remaining, setRemaining] = useState<number>(startCount.getTime());
-
-    useInterval(() => {
-        setRemaining((prev) => prev - interval);
-    }, interval);
-
-    useEffect(() => {
-        if (remaining <= 0) {
-            onCountdownFinished?.();
-        }
-    }, [remaining, onCountdownFinished]);
-
-    if (remaining > 1000 * 60 * 60 * 24 * 2) {
-        const days = Math.ceil(remaining / (1000 * 60 * 60 * 24));
-        return (
-            <Text>
-                {prefix}
-                {days} dager
-                {suffix}
-            </Text>
-        );
-    }
-
-    if (remaining > 1000 * 60 * 60 * 24) {
-        const hours = Math.ceil(remaining / (1000 * 60 * 60));
-        return (
-            <Text>
-                {prefix}
-                {hours} timer
-                {suffix}
-            </Text>
-        );
-    }
-
-    if (remaining > 1000 * 60 * 60) {
-        const minutes = Math.ceil(remaining / (1000 * 60));
-        return (
-            <Text>
-                {prefix}
-                {minutes} minutter
-                {suffix}
-            </Text>
-        );
-    }
-
-    if (remaining > 1000 * 60) {
-        const seconds = Math.ceil(remaining / 1000);
-        return (
-            <Text>
-                {prefix}
-                {seconds} sekunder
-                {suffix}
-            </Text>
-        );
-    }
-
-    const hours = Math.floor((remaining / (1000 * 60 * 60)) % 24);
-    const minutes = Math.floor((remaining / (1000 * 60)) % 60);
-    const seconds = Math.floor((remaining / 1000) % 60);
-
-    // Ledd som er null tas bort. «0 timer, 0 minutter og 41 sekunder» brakk
-    // over to linjer i knappen og leste som om noe var galt — «41 sekunder»
-    // sier det samme og får plass.
-    const parts = [
-        hours > 0 && `${hours} ${hours === 1 ? "time" : "timer"}`,
-        minutes > 0 && `${minutes} ${minutes === 1 ? "minutt" : "minutter"}`,
-        seconds > 0 && `${seconds} ${seconds === 1 ? "sekund" : "sekunder"}`,
-    ].filter(Boolean) as string[];
-
-    const spelled =
-        parts.length > 1
-            ? `${parts.slice(0, -1).join(", ")} og ${parts[parts.length - 1]}`
-            : (parts[0] ?? "et øyeblikk");
-
-    return (
-        <Text>
-            {prefix}
-            {spelled}
-            {suffix}
-        </Text>
-    );
 }

--- a/lib/events/registrationState.test.ts
+++ b/lib/events/registrationState.test.ts
@@ -1,0 +1,247 @@
+import type { Event, Registration } from "@/actions/types";
+import {
+    deriveRegistrationState,
+    formatCountdown,
+    formatTimeUntil,
+    registrationErrorMessage,
+} from "./registrationState";
+
+const NOW = new Date("2026-08-20T12:00:00Z");
+const past = (hours: number) =>
+    new Date(NOW.getTime() - hours * 3600_000).toISOString();
+const future = (hours: number) =>
+    new Date(NOW.getTime() + hours * 3600_000).toISOString();
+
+const event = (overrides: Partial<Event> = {}): Event =>
+    ({
+        id: "e1",
+        title: "Test",
+        start_date: future(48),
+        end_date: future(50),
+        sign_up: true,
+        closed: false,
+        limit: 0,
+        list_count: "0",
+        waiting_list_count: "0",
+        start_registration_at: past(1),
+        end_registration_at: future(24),
+        sign_off_deadline: future(20),
+        ...overrides,
+    }) as unknown as Event;
+
+const registration = (overrides: Partial<Registration> = {}): Registration =>
+    ({
+        has_attended: false,
+        has_paid_order: false,
+        is_on_wait: false,
+        payment_expiredate: "",
+        wait_queue_number: 0,
+        status: "registered",
+        ...overrides,
+    }) as unknown as Registration;
+
+describe("deriveRegistrationState", () => {
+    it("sier fra når arrangementet ikke har påmelding", () => {
+        expect(
+            deriveRegistrationState(event({ sign_up: false }), null, NOW),
+        ).toBe("no-signup");
+    });
+
+    it("er åpen innenfor påmeldingsvinduet", () => {
+        expect(deriveRegistrationState(event(), null, NOW)).toBe("open");
+    });
+
+    it("er ikke åpnet før påmeldingen starter", () => {
+        expect(
+            deriveRegistrationState(
+                event({ start_registration_at: future(2) }),
+                null,
+                NOW,
+            ),
+        ).toBe("not-open");
+    });
+
+    it("er stengt etter påmeldingsfristen", () => {
+        expect(
+            deriveRegistrationState(
+                event({ end_registration_at: past(1) }),
+                null,
+                NOW,
+            ),
+        ).toBe("closed");
+    });
+
+    it("er stengt når arrangementet er over, selv om flagget ikke er satt", () => {
+        expect(
+            deriveRegistrationState(
+                event({ start_date: past(5), end_date: past(3) }),
+                null,
+                NOW,
+            ),
+        ).toBe("closed");
+    });
+
+    it("er stengt når arrangøren har stengt manuelt", () => {
+        expect(deriveRegistrationState(event({ closed: true }), null, NOW)).toBe(
+            "closed",
+        );
+    });
+
+    it("er fullt når plassene er tatt", () => {
+        expect(
+            deriveRegistrationState(
+                event({ limit: 2, list_count: "2" }),
+                null,
+                NOW,
+            ),
+        ).toBe("full");
+    });
+
+    it("lar stengt gå foran fullt", () => {
+        expect(
+            deriveRegistrationState(
+                event({ limit: 2, list_count: "2", closed: true }),
+                null,
+                NOW,
+            ),
+        ).toBe("closed");
+    });
+
+    it("er påmeldt på et gratis arrangement", () => {
+        expect(deriveRegistrationState(event(), registration(), NOW)).toBe(
+            "joined",
+        );
+    });
+
+    it("venter på betaling når plassen ikke er betalt", () => {
+        expect(
+            deriveRegistrationState(
+                event({ is_paid_event: true }),
+                registration(),
+                NOW,
+            ),
+        ).toBe("awaiting-payment");
+    });
+
+    it("er påmeldt når den betalte plassen er gjort opp", () => {
+        expect(
+            deriveRegistrationState(
+                event({ is_paid_event: true }),
+                registration({ has_paid_order: true }),
+                NOW,
+            ),
+        ).toBe("joined");
+    });
+
+    it("viser oppmøtt som påmeldt, ikke som ubetalt", () => {
+        expect(
+            deriveRegistrationState(
+                event({ is_paid_event: true }),
+                registration({ status: "attended" }),
+                NOW,
+            ),
+        ).toBe("joined");
+    });
+
+    it("er på venteliste", () => {
+        expect(
+            deriveRegistrationState(
+                event(),
+                registration({ status: "waitlisted" }),
+                NOW,
+            ),
+        ).toBe("on-waitlist");
+    });
+
+    it("behandler en påmelding som ikke er avgjort", () => {
+        expect(
+            deriveRegistrationState(
+                event({ is_paid_event: true }),
+                registration({ status: "pending" }),
+                NOW,
+            ),
+        ).toBe("processing");
+    });
+
+    it("lar en kansellert påmelding falle tilbake til vinduet", () => {
+        expect(
+            deriveRegistrationState(
+                event(),
+                registration({ status: "cancelled" }),
+                NOW,
+            ),
+        ).toBe("open");
+    });
+});
+
+describe("formatCountdown", () => {
+    it("teller ned i minutter og sekunder", () => {
+        expect(formatCountdown(new Date(NOW.getTime() + 572_000).toISOString(), NOW)).toBe(
+            "9:32",
+        );
+    });
+
+    it("polstrer sekundene", () => {
+        expect(formatCountdown(new Date(NOW.getTime() + 14_000).toISOString(), NOW)).toBe(
+            "0:14",
+        );
+    });
+
+    it("runder opp, så en frist som løper aldri viser 0:00", () => {
+        expect(formatCountdown(new Date(NOW.getTime() + 200).toISOString(), NOW)).toBe(
+            "0:01",
+        );
+    });
+
+    it("gir null når fristen er passert", () => {
+        expect(formatCountdown(past(1), NOW)).toBeNull();
+    });
+
+    it("går over til grov tekst over en time", () => {
+        expect(formatCountdown(future(3), NOW)).toBe("3 timer");
+    });
+});
+
+describe("formatTimeUntil", () => {
+    it("bruker dager når det er langt fram", () => {
+        expect(formatTimeUntil(future(72), NOW)).toBe("3 dager");
+    });
+
+    it("bruker entall for én time", () => {
+        expect(formatTimeUntil(future(1), NOW)).toBe("en time");
+    });
+
+    it("dropper tomme ledd og viser bare sekunder", () => {
+        expect(
+            formatTimeUntil(new Date(NOW.getTime() + 41_000).toISOString(), NOW),
+        ).toBe("41 sekunder");
+    });
+});
+
+describe("registrationErrorMessage", () => {
+    it("oversetter manglende regelgodkjenning", () => {
+        expect(
+            registrationErrorMessage(new Error("You must accept the event rules")),
+        ).toContain("godkjenne arrangementsreglene");
+    });
+
+    it("forklarer at arrangementet er forbeholdt en prioritert gruppe", () => {
+        expect(
+            registrationErrorMessage(new Error("not in priority pool")),
+        ).toContain("prioritert gruppe");
+    });
+
+    it("plukker ut instituttet fra meldingen", () => {
+        expect(
+            registrationErrorMessage(
+                new Error("Event is only open to students at IDI"),
+            ),
+        ).toBe("Dette arrangementet er kun for studenter ved IDI.");
+    });
+
+    it("faller tilbake på API-meldingen når den er ukjent", () => {
+        expect(registrationErrorMessage(new Error("Noe helt annet"))).toBe(
+            "Noe helt annet",
+        );
+    });
+});

--- a/lib/events/registrationState.ts
+++ b/lib/events/registrationState.ts
@@ -1,0 +1,203 @@
+import type { Event, Registration } from "@/actions/types";
+
+/**
+ * Tilstandene påmeldingskortet kan stå i.
+ *
+ * Portert fra nettsidas `deriveRegistrationState`, slik at appen og nettsida
+ * sier det samme om det samme arrangementet. Skjermen hadde tidligere en
+ * håndfull løse booleans som ikke dekket venteliste, betaling eller en
+ * påmelding som fortsatt behandles.
+ */
+export type EventRegistrationState =
+    | "no-signup"
+    | "not-open"
+    | "open"
+    | "processing"
+    | "joined"
+    | "awaiting-payment"
+    | "on-waitlist"
+    | "closed"
+    | "full";
+
+/**
+ * Facebook-gruppa der medlemmer kjøper og selger billetter. Samme gruppe som
+ * nettsida lenker til, så folk finner igjen det de er vant til.
+ */
+export const TICKET_RESALE_GROUP_URL =
+    "https://www.facebook.com/groups/598608738731749/";
+
+/**
+ * Avled tilstanden fra egen påmelding og arrangementets påmeldingsvindu.
+ *
+ * Hver grense teller selv om Photon uansett avviser en påmelding utenfor
+ * vinduet: uten dem sto det en innbydende «Meld deg på» både før påmeldingen
+ * åpnet og lenge etter at arrangementet var over, siden `closed` er et flagg
+ * arrangørene sjelden setter.
+ */
+export function deriveRegistrationState(
+    event: Event,
+    registration: Registration | null | undefined,
+    now: Date = new Date(),
+): EventRegistrationState {
+    // Arrangementer uten påmelding har ingenting å melde seg på.
+    if (event.sign_up !== true) return "no-signup";
+
+    const isPaidEvent =
+        event.is_paid_event === true || Boolean(event.paid_information?.price);
+
+    switch (registration?.status) {
+        // En plass på et betalt arrangement er reservert, ikke sikret, før den
+        // er betalt: det er der betalingsknappen hører hjemme. Uten dette fikk
+        // medlemmet «Du har plass» og ingen måte å betale på — og plassen ble
+        // tatt tilbake da fristen gikk ut.
+        case "registered":
+            return isPaidEvent && registration.has_paid_order !== true
+                ? "awaiting-payment"
+                : "joined";
+        // Møtt opp betyr at arrangementet er i gang. Da er betalingen et
+        // oppgjør mellom medlemmet og arrangøren, ikke en knapp her.
+        case "attended":
+            return "joined";
+        case "waitlisted":
+            return "on-waitlist";
+        // Påmeldingen står som «pending» til serveren har avgjort om det ble
+        // plass eller venteliste. Photon avviser betaling før det er avgjort,
+        // så «behandler» gjelder også på betalte arrangementer.
+        case "pending":
+            return "processing";
+        default: {
+            if (event.closed === true) return "closed";
+            if (event.end_date && new Date(event.end_date) < now) return "closed";
+            if (
+                event.end_registration_at &&
+                new Date(event.end_registration_at) < now
+            ) {
+                return "closed";
+            }
+            if (
+                event.start_registration_at &&
+                new Date(event.start_registration_at) > now
+            ) {
+                return "not-open";
+            }
+            // Sist av alle grensene: at plassene er tatt betyr ingenting så
+            // lenge påmeldingen er stengt eller ikke åpnet — da er det det som
+            // skal stå.
+            const capacity = event.limit ?? 0;
+            const registered = Number(event.list_count ?? 0);
+            if (capacity > 0 && registered >= capacity) return "full";
+            return "open";
+        }
+    }
+}
+
+/**
+ * «9:32», «0:14» — tida igjen på en frist som løper mens medlemmet ser på.
+ *
+ * Betalingsfristen er kort, så en frist på klokka sier lite: sekundene er hele
+ * poenget med at den teller ned. Over en time er den grove teksten bedre —
+ * «58:12» sier mindre enn «snart en time».
+ *
+ * Returnerer `null` når fristen er passert.
+ */
+export function formatCountdown(
+    iso: string,
+    now: Date = new Date(),
+): string | null {
+    const remainingMs = new Date(iso).getTime() - now.getTime();
+    if (Number.isNaN(remainingMs) || remainingMs <= 0) return null;
+
+    if (remainingMs >= 60 * 60 * 1000) {
+        const hours = Math.round(remainingMs / (60 * 60 * 1000));
+        return hours === 1 ? "en time" : `${hours} timer`;
+    }
+
+    // Rundes opp: med 200 ms igjen står det «0:01», ikke «0:00» — det siste
+    // ville sagt at fristen var ute mens den fortsatt løp.
+    const totalSeconds = Math.ceil(remainingMs / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/**
+ * «2 dager», «3 timer», «34 sekunder» — halen på «Påmelding åpner om …».
+ *
+ * Grov med vilje: for noe som åpner om dager sier sekunder ingenting. Ledd som
+ * er null tas bort, så det aldri står «0 timer, 0 minutter og 41 sekunder».
+ */
+export function formatTimeUntil(iso: string, now: Date = new Date()): string {
+    const ms = new Date(iso).getTime() - now.getTime();
+    if (Number.isNaN(ms) || ms <= 0) return "et øyeblikk";
+
+    const days = Math.floor(ms / (24 * 60 * 60 * 1000));
+    if (days >= 2) return `${days} dager`;
+
+    const hours = Math.floor(ms / (60 * 60 * 1000));
+    if (hours >= 1) return hours === 1 ? "en time" : `${hours} timer`;
+
+    const minutes = Math.floor(ms / (60 * 1000));
+    if (minutes >= 1) return minutes === 1 ? "ett minutt" : `${minutes} minutter`;
+
+    const seconds = Math.max(1, Math.ceil(ms / 1000));
+    return seconds === 1 ? "ett sekund" : `${seconds} sekunder`;
+}
+
+/**
+ * Oversett en feil fra påmeldings- eller betalingsendepunktet til noe et
+ * medlem forstår.
+ *
+ * Photons meldinger er engelske og skrevet for utviklere. De vanligste
+ * årsakene får en norsk forklaring; resten faller tilbake på API-meldingen,
+ * som fortsatt er bedre enn ingenting. Her havner også avvisningene som
+ * forteller at arrangementet ikke er for deg — prioriterte grupper, institutt
+ * eller manglende rettighet.
+ */
+export function registrationErrorMessage(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes("not open for registration")) {
+        return "Dette arrangementet er ikke åpent for påmelding.";
+    }
+    if (message.includes("already registered")) {
+        return "Du er allerede påmeldt. Dra ned for å oppdatere.";
+    }
+    if (message.includes("accept the event rules")) {
+        return "Du må godkjenne arrangementsreglene før du kan melde deg på. Huk av i varselet over.";
+    }
+    if (message.includes("priority pool")) {
+        return "Dette arrangementet er forbeholdt medlemmer i en prioritert gruppe.";
+    }
+    if (message.includes("only open to students at")) {
+        const institute = message.split("only open to students at")[1]?.trim();
+        return institute
+            ? `Dette arrangementet er kun for studenter ved ${institute}.`
+            : "Dette arrangementet er kun for studenter ved ett bestemt institutt.";
+    }
+    if (message.includes("requires permission")) {
+        return "Kontoen din har ikke tilgang til å melde seg på arrangementer. Ta kontakt med Index hvis dette ser feil ut.";
+    }
+    if (message.includes("Authentication required")) {
+        return "Du må være innlogget for å melde deg på.";
+    }
+    if (message.includes("not registered")) {
+        return "Du er ikke påmeldt dette arrangementet.";
+    }
+    if (message.includes("pending payment already exists")) {
+        return "Du har allerede en betaling på gang i Vipps. Fullfør den der, eller vent et minutt og prøv igjen.";
+    }
+    if (message.includes("already paid")) {
+        return "Plassen er allerede betalt. Dra ned for å oppdatere.";
+    }
+    if (message.includes("register for the event before paying")) {
+        return "Du må ha en plass på arrangementet før du kan betale.";
+    }
+    if (message.includes("does not require payment")) {
+        return "Dette arrangementet krever ingen betaling.";
+    }
+    if (message.includes("Failed to initiate Vipps payment")) {
+        return "Vipps svarte ikke. Prøv igjen om litt — plassen din står så lenge fristen ikke har gått ut.";
+    }
+
+    return message;
+}


### PR DESCRIPTION
Tar resten av gapet mot `apps/kvark`. **Bygger på #139** — merge den først, så retter denne seg mot `main`.

## Foranliggende datafeil

Egen påmelding ble lett opp ved å hente hele påmeldingslista og matche på e-post. Photon oppgir e-post **kun til arrangementsadmin** (`EventRegisteredUser.email`: *«Only included for event admins»*), så for vanlige medlemmer fant den aldri noe — appen trodde ingen var påmeldt.

Photon legger påmeldingen på selve arrangementet i stedet, med `status`, `waitlistPosition`, `hasPaid` og `paymentExpiresAt`. Den følger bare med når kallet er autentisert, og `fetchEvent` brukte `fetch()` uten token — så feltet kom aldri fram. Sender nå token når sesjonen finnes, og faller tilbake til åpent kall ellers.

## Tilstandsmaskinen

`kvark/src/lib/event.ts` er portert til `lib/events/registrationState.ts`. Kortet hadde løse booleans (`isDisabled`, `showCountdown`, `isDestructive`) som ikke dekket venteliste, betaling eller en påmelding som fortsatt behandles — så appen sa noe annet enn nettsida om det samme arrangementet.

Ni tilstander: `no-signup`, `not-open`, `open`, `processing`, `joined`, `awaiting-payment`, `on-waitlist`, `closed`, `full`.

## Det som var på lista

| Punkt | Løst med |
|---|---|
| Venteliste som egen handling + posisjon | `on-waitlist`/`full`, med posisjon fra `waitlistPosition` |
| Betalingsfrist som nedtelling | `formatCountdown` → «9:32», og egen tekst når fristen er gått ut |
| `hasPaid` skjuler avmelding | Avmeldingsknappen vises ikke for en betalt plass — Photon avviser den uansett |
| Videresalg av billett | «Selg billetten din» → Facebook-gruppa, kun når plassen er betalt |
| Feilmelding fra siste forsøk | `registrationErrorMessage` oversetter Photons meldinger til norsk |

**`not-eligible` er ikke portert, og det var min feil i tabellen.** Tilstanden finnes i nettsidas type og kortet håndterer den, men ingenting produserer den — `notEligibleReason` settes aldri. Ineligibilitet kommer i praksis som API-feil, og de er dekket av oversettelsene («priority pool», «only open to students at», «requires permission»).

## Verifisert

| Sjekk | Status |
|---|---|
| `npx jest lib/events` | ✅ **27 tester passerer** |
| `tsc --noEmit` | ✅ exit 0 |
| `expo lint` | ✅ 0 errors (3 warnings, alle fra før) |
| Skjermen rendrer | ✅ ingen krasj, ingen runtime-feil i Metro |
| **Tilstandene i appen** | ❌ **ikke klikket gjennom** |

Testene dekker logikken — alle ni tilstandene, grensene mellom dem, nedtellingene og feiloversettelsene. Selve kortet er ikke sett i drift: simulatorens HID-port er død på maskinen min, så jeg får rendret sida men ikke rullet ned til kortet. Verdt en runde på enhet, særlig venteliste og betaling, som krever ekte data å havne i.

## Bonus

`CountTextWrapper` er fjernet — nedtellingene ligger nå i `registrationState` med tester. Det tok samtidig bort en `react-hooks/exhaustive-deps`-warning som har stått en stund.

🤖 Generated with [Claude Code](https://claude.com/claude-code)