### PR TITLE
fix: fjern bakgrunnsstripa bak den krympede faneraden

### DIFF
--- a/app/(app)/(tabs)/arrangementer/index.tsx
+++ b/app/(app)/(tabs)/arrangementer/index.tsx
@@ -4,7 +4,7 @@ import { Text } from "@/components/ui/text";
 import { router, Stack } from "expo-router";
 import { ActivityIndicator, FlatList, Pressable, TextInput, View } from "react-native";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES } from "@/components/ui/pagewrapper";
 import { fetchEvents as fetchEventList, fetchFavoriteEvents } from "@/actions/events/events";
 import type { Event } from "@/actions/types";
 import useRefresh from "@/lib/useRefresh";
@@ -141,7 +141,7 @@ export default function Arrangementer() {
                     ),
                 }}
             />
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <FlatList
                     data={allEvents}
                     showsVerticalScrollIndicator={false}

--- a/app/(app)/(tabs)/bot/index.tsx
+++ b/app/(app)/(tabs)/bot/index.tsx
@@ -1,7 +1,7 @@
 import { avatarImageUrl } from "@/lib/images";
 import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES, TAB_BAR_CLEARANCE } from "@/components/ui/pagewrapper";
 import useRefresh from "@/lib/useRefresh";
 import { useColorScheme } from "@/lib/useColorScheme";
 import { fetchMemberships } from "@/actions/fines/memberships";
@@ -39,11 +39,11 @@ export default function MembershipSelection() {
         memberships.data?.filter((m: Membership) => m.group.fines_activated) ?? [];
 
     return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <FlatList
                 data={finesGroups}
                 showsVerticalScrollIndicator={false}
-                contentContainerStyle={{ paddingTop: 12, paddingBottom: 40 }}
+                contentContainerStyle={{ paddingTop: 12, paddingBottom: TAB_BAR_CLEARANCE }}
                 refreshControl={refreshControl}
                 keyExtractor={(item) => item.group.slug}
                 renderItem={({ item: membership }) => (

--- a/app/(app)/(tabs)/grupper/index.tsx
+++ b/app/(app)/(tabs)/grupper/index.tsx
@@ -1,7 +1,7 @@
 import { avatarImageUrl } from "@/lib/images";
 import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES, TAB_BAR_CLEARANCE } from "@/components/ui/pagewrapper";
 import useRefresh from "@/lib/useRefresh";
 import { useColorScheme } from "@/lib/useColorScheme";
 import { fetchMemberships } from "@/actions/fines/memberships";
@@ -64,11 +64,11 @@ export default function Grupper() {
         ) ?? [];
 
     return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <FlatList
                 data={groups}
                 showsVerticalScrollIndicator={false}
-                contentContainerStyle={{ paddingTop: 12, paddingBottom: 40 }}
+                contentContainerStyle={{ paddingTop: 12, paddingBottom: TAB_BAR_CLEARANCE }}
                 refreshControl={refreshControl}
                 keyExtractor={(item) => item.group.slug}
                 renderItem={({ item: membership }: { item: Membership }) => (

--- a/app/(app)/(tabs)/karriere/[karriereId].tsx
+++ b/app/(app)/(tabs)/karriere/[karriereId].tsx
@@ -8,7 +8,7 @@ import { Pressable, ScrollView, View } from "react-native";
 import CoverImage, { COVER_IMAGE_FRAME } from "@/components/ui/coverImage";
 import * as WebBrowser from 'expo-web-browser';
 import MarkdownView from "@/components/ui/MarkdownView";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES } from "@/components/ui/pagewrapper";
 import { fetchJobPost } from "@/actions/events/events";
 import useRefresh from "@/lib/useRefresh";
 import { useColorScheme } from "@/lib/useColorScheme";
@@ -54,7 +54,7 @@ function DetailRow({
 
 function DetailSkeleton() {
     return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <ScrollView showsVerticalScrollIndicator={false}>
                 {/* Image skeleton */}
                 <View className={`${COVER_IMAGE_FRAME} bg-muted dark:bg-secondary/40 animate-pulse`} />
@@ -118,7 +118,7 @@ export default function Karriereside() {
     );
 
     if (jobpost.isError) return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <Stack.Screen options={{ title: "" }} />
             <View className="flex-1 items-center justify-center px-6">
                 <Text className="text-base text-destructive">{jobpost.error.message}</Text>
@@ -145,7 +145,7 @@ export default function Karriereside() {
     return (
         <>
             <Stack.Screen options={{ title: jobpost.data.company }} />
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <ScrollView
                     refreshControl={refreshControl}
                     showsVerticalScrollIndicator={false}

--- a/app/(app)/(tabs)/karriere/index.tsx
+++ b/app/(app)/(tabs)/karriere/index.tsx
@@ -1,7 +1,7 @@
 import { themeColors } from "@/lib/theme/colors";
 import { fetchJobPosts } from "@/actions/events/events";
 import JobPostCard, { JobPostCardSkeleton } from "@/components/karriere/jobpostcard";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES } from "@/components/ui/pagewrapper";
 import { Text } from "@/components/ui/text";
 import { SectionHeader } from "@/components/ui/section-header";
 import useRefresh from "@/lib/useRefresh";
@@ -25,7 +25,7 @@ export default function Karriere() {
 
     if (jobposts.isError) {
         return (
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <View className="flex-1 items-center justify-center px-6">
                     <Text className="text-base text-destructive">{jobposts.error.message}</Text>
                 </View>
@@ -36,7 +36,7 @@ export default function Karriere() {
     const resultCount = jobposts.data?.results?.length ?? 0;
 
     return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <ScrollView
                 refreshControl={refreshControl}
                 showsVerticalScrollIndicator={false}

--- a/app/(app)/(tabs)/profil/allergier.tsx
+++ b/app/(app)/(tabs)/profil/allergier.tsx
@@ -5,7 +5,7 @@ import {
     settingsKeys,
     updateMySettings,
 } from "@/actions/users/settings";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES, TAB_BAR_CLEARANCE } from "@/components/ui/pagewrapper";
 import { Text } from "@/components/ui/text";
 import { themeColors } from "@/lib/theme/colors";
 import { useColorScheme } from "@/lib/useColorScheme";
@@ -93,7 +93,7 @@ export default function Allergier() {
 
     if (settings.isPending || allergies.isPending) {
         return (
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <View className="flex-1 items-center justify-center">
                     <ActivityIndicator size="large" />
                 </View>
@@ -103,7 +103,7 @@ export default function Allergier() {
 
     if (settings.isError || allergies.isError) {
         return (
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <View className="flex-1 items-center justify-center px-6">
                     <Text className="text-base text-destructive text-center">
                         {(settings.error ?? allergies.error)?.message}
@@ -140,7 +140,7 @@ export default function Allergier() {
             selected.every((slug) => settings.data.allergies.includes(slug)));
 
     return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <View className="flex-1">
                 <FlatList
                     data={suggestions}
@@ -238,7 +238,10 @@ export default function Allergier() {
 
                 {/* Faneraden flyter over innholdet, så knappen trenger luft
                     under seg for ikke å ligge klemt inntil den. */}
-                <View className="px-5 pb-6 pt-2 border-t border-border dark:border-muted">
+                <View
+                    className="px-5 pt-2 border-t border-border dark:border-muted"
+                    style={{ paddingBottom: TAB_BAR_CLEARANCE }}
+                >
                     <Pressable
                         onPress={() => save.mutate(current)}
                         disabled={isUnchanged || save.isPending}

--- a/app/(app)/(tabs)/profil/index.tsx
+++ b/app/(app)/(tabs)/profil/index.tsx
@@ -4,7 +4,7 @@ import me, { myEvents } from "@/actions/users/me";
 import EventCard, {
     EventCardSkeleton,
 } from "@/components/arrangement/eventCard";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES } from "@/components/ui/pagewrapper";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { Text } from "@/components/ui/text";
 import { useAuth } from "@/context/auth";
@@ -54,7 +54,7 @@ export default function Profil() {
 
     if (user.isPending) {
         return (
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <ScrollView
                     refreshControl={refreshControl}
                     contentContainerStyle={{ flexGrow: 1 }}
@@ -71,7 +71,7 @@ export default function Profil() {
 
     if (user.isError) {
         return (
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <ScrollView
                     refreshControl={refreshControl}
                     contentContainerStyle={{ flexGrow: 1 }}
@@ -119,7 +119,7 @@ export default function Profil() {
     const events = tab === 0 ? registered : favorites;
 
     return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <ScrollView
                 refreshControl={refreshControl}
                 showsVerticalScrollIndicator={false}

--- a/app/(app)/(tabs)/profil/innstillinger.tsx
+++ b/app/(app)/(tabs)/profil/innstillinger.tsx
@@ -5,7 +5,7 @@ import {
     updateMySettings,
 } from "@/actions/users/settings";
 import { ThemeSwitch } from "@/components/themeToggle";
-import PageWrapper from "@/components/ui/pagewrapper";
+import PageWrapper, { TAB_SCREEN_EDGES, TAB_BAR_CLEARANCE } from "@/components/ui/pagewrapper";
 import { SectionHeader } from "@/components/ui/section-header";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { Switch } from "@/components/ui/switch";
@@ -159,7 +159,7 @@ export default function Innstillinger() {
 
     if (settings.isPending) {
         return (
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <View className="flex-1 items-center justify-center">
                     <ActivityIndicator size="large" />
                 </View>
@@ -169,7 +169,7 @@ export default function Innstillinger() {
 
     if (settings.isError) {
         return (
-            <PageWrapper className="flex-1 bg-background">
+            <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
                 <View className="flex-1 items-center justify-center px-6">
                     <Text className="text-base text-destructive text-center">
                         {settings.error.message}
@@ -203,11 +203,11 @@ export default function Innstillinger() {
     };
 
     return (
-        <PageWrapper className="flex-1 bg-background">
+        <PageWrapper className="flex-1 bg-background" edges={TAB_SCREEN_EDGES}>
             <ScrollView
                 refreshControl={refreshControl}
                 showsVerticalScrollIndicator={false}
-                contentContainerStyle={{ paddingBottom: 60 }}
+                contentContainerStyle={{ paddingBottom: TAB_BAR_CLEARANCE }}
             >
                 {/* Utseende */}
                 <View className="px-5 pt-5">

--- a/components/ui/pagewrapper.tsx
+++ b/components/ui/pagewrapper.tsx
@@ -1,17 +1,35 @@
-import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaProvider, SafeAreaView, type Edge } from "react-native-safe-area-context";
 
 interface PageWrapperProps {
     children: React.ReactNode;
     className?: string;
+    /**
+     * Hvilke kanter som skal få safe-area-padding. Skjermer som ligger under
+     * tab-baren sender inn `TAB_SCREEN_EDGES`: der eier tab-baren bunnen, og
+     * padding her ville lagt en stripe med bakgrunnsfarge over innholdet —
+     * synlig så snart Liquid Glass-baren krymper inn til venstre.
+     */
+    edges?: readonly Edge[];
 }
 
-export default function PageWrapper({ children, className }: PageWrapperProps) {
+/** Alt unntatt bunnen — for skjermer som ligger under tab-baren. */
+export const TAB_SCREEN_EDGES = ["top", "left", "right"] as const;
+
+export default function PageWrapper({ children, className, edges }: PageWrapperProps) {
 
     return (
         <SafeAreaProvider>
-            <SafeAreaView className={`flex-1 ${className ?? ""}`}>
+            <SafeAreaView className={`flex-1 ${className ?? ""}`} edges={edges}>
                 {children}
             </SafeAreaView>
         </SafeAreaProvider>
     )
 }
+
+/**
+ * Luft som må ligge under rullende innhold på skjermer med tab-bar. Baren
+ * flyter over innholdet (og safe-area-paddingen er skrudd av, se
+ * `TAB_SCREEN_EDGES`), så uten dette blir det nederste elementet liggende
+ * permanent bak glasset — det kan ikke rulles fram.
+ */
+export const TAB_BAR_CLEARANCE = 100;


### PR DESCRIPTION
## Problemet

Når man scroller og Liquid Glass-faneraden krymper inn til venstre, lå det en mørk bakgrunnsstripe over bunnen av skjermen. Kun selve faneraden skal være der.

## Årsaken

`PageWrapper` la safe-area-padding i **bunnen** på hver skjerm, samtidig som containeren har `bg-background`. Rullelista stoppet dermed over home-indikatoren, og den solide bakgrunnsfargen fylte stripa under. Faneraden selv har ingen bakgrunn i det hele tatt — bjelken kom fra skjermene.

## Endringen

- `PageWrapper` tar nå en `edges`-prop. Skjermene under `(tabs)/` sender inn `TAB_SCREEN_EDGES` (`top`/`left`/`right`) og dropper bunn-paddingen, så innholdet ruller helt ut til skjermkanten bak glasset.
- Modaler og login er urørt — der finnes ingen fanerad som eier bunnen, så de beholder bunn-paddingen.
- Uten safe-area-paddingen ble det nederste elementet liggende **permanent bak glasset** på skjermer med for lite klaring: «Logg ut» i Innstillinger og «Lagre» i Allergier kunne ikke rulles fram. `TAB_BAR_CLEARANCE = 100` gir disse — og listene i Bot og Grupper — nok luft under seg.

## Verifisering

`npx tsc --noEmit` rent. `expo lint` viser bare de tre advarslene som lå der fra før (`_layout.tsx`, `bekreft.tsx`, `MarkdownView.tsx` — alle urørt her).

Kjørt i simulator (iPhone 17 Pro, iOS 26) på hver fane:

| Skjerm | Status |
|---|---|
| Events | Bildet går til kanten, pillen ligger oppå — ingen stripe |
| Grupper | Ren bakgrunn til kanten |
| Karriere | Ren bakgrunn til kanten |
| Bot | Ren bakgrunn til kanten |
| Profil | Ren bakgrunn til kanten |
| Profil → Innstillinger | «Logg ut» ruller klar av baren (var klemt) |
| Profil → Allergier | «Lagre» ligger klar av baren (var klemt) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)