### PR TITLE
refactor: fjern oppslaget mot påmeldingslista for egen påmelding

### DIFF
--- a/actions/events/registrations.ts
+++ b/actions/events/registrations.ts
@@ -1,44 +1,6 @@
-import { apiFetch, apiJson } from "@/lib/api/client";
+import { apiFetch } from "@/lib/api/client";
 import { Registration } from "../types";
-import { toRegistration } from "@/actions/photon";
-import me from "../users/me";
-
-type PhotonRegisteredUser = {
-    id: string;
-    name: string;
-    email: string;
-    image: string | null;
-    status: string;
-    waitlistPosition: number | null;
-    attendedAt: string | null;
-    registeredAt: string;
-    payment: unknown | null;
-};
-
-type PhotonRegistrations = {
-    registeredUsers: PhotonRegisteredUser[];
-    totalCount: number;
-    nextPage: number | null;
-};
-
-/**
- * Photon har ingen «hent min påmelding»-rute. Lista hentes i stedet og filtreres
- * på egen bruker — samme antall kall som før, siden Lepton-varianten også måtte
- * slå opp brukeren først.
- */
-export async function iAmRegisteredToEvent(eventId: string): Promise<Registration | null> {
-    const [user, data] = await Promise.all([
-        me(),
-        apiJson<PhotonRegistrations>(
-            `/event/${encodeURIComponent(String(eventId))}/registration?pageSize=500`
-        ).catch(() => null),
-    ]);
-
-    const mine = data?.registeredUsers.find(
-        (registered) => registered.email === user.email
-    );
-    return mine ? toRegistration(mine) : null;
-}
+import { PhotonRegisteredUser, toRegistration } from "@/actions/photon";
 
 export async function registerToEvent(eventId: string): Promise<Registration> {
     // Photon krever en JSON-body her (`requestBody.required`), og `apiFetch`

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -6,7 +6,7 @@ import MarkdownView from "@/components/ui/MarkdownView";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import PageWrapper from "@/components/ui/pagewrapper";
 import { fetchEvent, fetchEventCounts } from "@/actions/events/events";
-import { iAmRegisteredToEvent, registerToEvent, unregisterFromEvent } from "@/actions/events/registrations";
+import { registerToEvent, unregisterFromEvent } from "@/actions/events/registrations";
 import { Event, Registration } from "@/actions/types";
 import { useRef, useState } from "react";
 import useInterval from "@/lib/useInterval";
@@ -174,11 +174,6 @@ export default function ArrangementSide() {
         queryFn: async (): Promise<Event> => {
             return fetchEvent(String(id));
         },
-    });
-
-    const { data: registration, isPending: registrationPending } = useQuery({
-        queryKey: ["event", id, "registration"],
-        queryFn: async () => iAmRegisteredToEvent(String(id)),
     });
 
     // Tallene ligger ikke på arrangementet i Photon; de telles på
@@ -381,8 +376,6 @@ export default function ArrangementSide() {
 
                                 <RegistrationButton
                                     event={event.data}
-                                    registration={registration}
-                                    registrationPending={registrationPending}
                                     mutationPending={registrationMutation.isPending}
                                     mutationError={registrationMutation.error}
                                     onClick={() => registrationMutation.mutate(String(id))}
@@ -659,16 +652,12 @@ function EventParticipantsModal({ eventId, totalCount }: { eventId: string; tota
  */
 function RegistrationButton({
     event,
-    registration,
-    registrationPending,
     onClick,
     mutationPending,
     mutationError,
     unregisterSheetRef,
 }: {
     event: Event;
-    registration?: Registration | null;
-    registrationPending?: boolean;
     onClick?: () => void;
     mutationPending?: boolean;
     mutationError?: unknown;
@@ -683,9 +672,11 @@ function RegistrationButton({
     const [now, setNow] = useState<Date>(() => new Date());
     useInterval(() => setNow(new Date()), 1000);
 
-    // Photon legger egen påmelding på arrangementet. `registration` er igjen
-    // fra da den måtte letes opp i påmeldingslista, og brukes som reserve.
-    const mine = event.my_registration ?? registration ?? null;
+    // Photon legger egen påmelding på arrangementet: `GET /event/:id` svarer
+    // med medlemmets egen rad uansett status, med betaling og frist. Lista over
+    // påmeldte kan ikke brukes til dette — den skjuler status, e-post og
+    // betaling for alle uten arrangementstilgang.
+    const mine = event.my_registration ?? null;
     const state = deriveRegistrationState(event, mine, now);
 
     // Bare tilstandene der medlemmet ellers kunne meldt seg på — å be noen
@@ -693,12 +684,6 @@ function RegistrationButton({
     const blockedByEventRules =
         eventRules.mustAccept &&
         (state === "open" || state === "not-open" || state === "full");
-
-    if (registrationPending) {
-        return (
-            <View className="h-14 bg-muted dark:bg-secondary/40 rounded-2xl animate-pulse mb-2" />
-        );
-    }
 
     const errorText = mutationError
         ? registrationErrorMessage(mutationError)


### PR DESCRIPTION
## Hva

Fjerner `iAmRegisteredToEvent` fra `actions/events/registrations.ts` og spørringa som brukte den i arrangementsskjermen.

## Hvorfor

Funksjonen hentet hele påmeldingslista (`/event/:id/registration?pageSize=500`) og lette etter seg selv med `registered.email === user.email`. Photons listerute sender bare `id`, `image`, `name` og `isAnonymous` til kallere uten `events:update` / `events:manage` / `events:registrations:view` — e-post, status, ventelisteplass og betaling er admin-felt ([`apps/api/src/routes/event/registration/list.ts`](https://github.com/TIHLDE/Photon/blob/main/apps/api/src/routes/event/registration/list.ts) ~linje 190-225). For vanlige medlemmer slo matchen derfor aldri til, og funksjonen returnerte alltid `null`. Lista filtrerer dessuten bort venteliste og avbrutt som standard (`DEFAULT_STATUSES`).

`GET /event/:id` slår allerede opp medlemmets egen rad uten statusfilter og legger på betaling og frist ([`routes/event/get.ts:123-160`](https://github.com/TIHLDE/Photon/blob/main/apps/api/src/routes/event/get.ts)). Den lå alt som førstevalg i skjermen (`event.my_registration ?? registration`), så reserven kostet to nettverkskall per arrangementsvisning — `me()` pluss lista på 500 rader — uten å kunne gi et svar. En id-match mot egen bruker-id ville byttet de samme to kallene mot en versjon uten status og betaling, altså dårligere data enn appen allerede har.

## Endringer

- `actions/events/registrations.ts` — funksjonen, `PhotonRegistrations`-typen, `me()`-importen og den lokale `PhotonRegisteredUser`-duplikaten er ute. `registerToEvent` bruker nå typen som allerede eksporteres fra `actions/photon.ts`.
- `app/(app)/(modals)/arrangement/[arrangementId].tsx` — spørringa `["event", id, "registration"]` og propsene `registration` / `registrationPending` er fjernet. `mine` leser bare `event.my_registration`. Kommentaren over sier nå hvorfor lista ikke kan brukes til dette, så reserven ikke kommer tilbake.

Skjelettet `registrationPending` styrte var dødt uansett: skjermen returnerer på `event.isPending` før knappen tegnes, så laste-tilstanden var allerede dekket.

## Verifisert

- `npx tsc --noEmit` — rent
- `npx expo lint` — 0 errors (3 warnings, alle eksisterende fra før i `_layout.tsx`, `bekreft.tsx` og `MarkdownView.tsx`)
- `npx jest` — 27/27

Ikke kjørt i simulator. Påmeldingsknappen på et betalt arrangement og et med venteliste bør sees over før merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)