### PR TITLE
Betaling: åpne Vipps i stedet for en utlogget nettleser

### DIFF
--- a/actions/events/payments.ts
+++ b/actions/events/payments.ts
@@ -1,5 +1,5 @@
 import { apiJson } from "@/lib/api/client";
-import { Payment } from "../types";
+import { PhotonPayment, toPayment } from "@/actions/photon";
 import * as Linking from "expo-linking";
 
 /**
@@ -16,7 +16,7 @@ export async function createPayment(eventid: string) {
     // `NATIVE_REDIRECT` finnes nettopp for apper: betalingsleverandøren
     // sender brukeren tilbake til `tihlde://arrangement/<id>` i stedet for å
     // etterlate dem i nettleseren.
-    return apiJson<Payment>(
+    const payment = await apiJson<PhotonPayment>(
         `/event/${encodeURIComponent(String(eventid))}/payment`,
         {
             method: "POST",
@@ -26,4 +26,6 @@ export async function createPayment(eventid: string) {
             }),
         }
     );
+
+    return toPayment(payment);
 }

--- a/actions/events/payments.ts
+++ b/actions/events/payments.ts
@@ -29,3 +29,32 @@ export async function createPayment(eventid: string) {
 
     return toPayment(payment);
 }
+
+export type PaymentConfirmation = {
+    /**
+     * `pending` betyr at checkouten fortsatt er åpen, eller at Photon ikke
+     * fikk svar fra Vipps: spør igjen om litt. `none` betyr at det ikke er
+     * noen utestående betaling å bekrefte.
+     */
+    status: "paid" | "pending" | "failed" | "none";
+};
+
+/**
+ * «Gikk betalinga gjennom?», spurt av medlemmet som nettopp kom tilbake fra
+ * Vipps.
+ *
+ * Vipps sender medlemmet tilbake i det de har godkjent, som regel før
+ * webhooken som registrerer betalingen har nådd Photon. Uten dette landet de
+ * på «betal for å sikre den» rett etter å ha betalt, og eneste vei ut var å
+ * dra ned til webhooken tilfeldigvis hadde kommet.
+ *
+ * Ruta ser bare på kallerens egen betaling.
+ */
+export async function confirmPayment(
+    eventId: string
+): Promise<PaymentConfirmation> {
+    return apiJson<PaymentConfirmation>(
+        `/event/${encodeURIComponent(String(eventId))}/payment/confirm`,
+        { method: "POST", body: JSON.stringify({}) }
+    );
+}

--- a/actions/photon.ts
+++ b/actions/photon.ts
@@ -18,6 +18,7 @@ import type {
     Law,
     Membership,
     Notification,
+    Payment,
     Registration,
     User,
     UserSettings,
@@ -501,3 +502,35 @@ export const toFineLeaderboardEntry = (
     finesAmount: user.finesAmount,
     finesCount: user.finesCount,
 });
+
+export type PhotonPayment = {
+    orderId?: string | null;
+    id?: string | null;
+    status?: string | null;
+    // Photon har navngitt lenka ulikt gjennom migrasjonen; alle formene under
+    // peker på det samme: der Vipps skal ta over.
+    paymentLink?: string | null;
+    paymentUrl?: string | null;
+    redirectUrl?: string | null;
+    url?: string | null;
+};
+
+/**
+ * Betalingslenka fra Photon.
+ *
+ * Appen leste `payment_link` rett fra svaret, men Photon svarer i camelCase.
+ * Feltet var derfor alltid undefined, og skjermen falt tilbake til
+ * arrangementssida på tihlde.org — en nettleser uten innlogging, der brukeren
+ * så ut til å ikke være påmeldt i det hele tatt.
+ */
+export const toPayment = (payment: PhotonPayment): Payment =>
+    ({
+        order_id: payment.orderId ?? payment.id ?? "",
+        status: payment.status ?? "",
+        payment_link:
+            payment.paymentLink ??
+            payment.paymentUrl ??
+            payment.redirectUrl ??
+            payment.url ??
+            "",
+    }) as unknown as Payment;

--- a/actions/photon.ts
+++ b/actions/photon.ts
@@ -504,33 +504,26 @@ export const toFineLeaderboardEntry = (
 });
 
 export type PhotonPayment = {
-    orderId?: string | null;
-    id?: string | null;
-    status?: string | null;
-    // Photon har navngitt lenka ulikt gjennom migrasjonen; alle formene under
-    // peker på det samme: der Vipps skal ta over.
-    paymentLink?: string | null;
-    paymentUrl?: string | null;
-    redirectUrl?: string | null;
-    url?: string | null;
+    eventId: string;
+    userId: string;
+    checkoutUrl: string;
+    amount: number;
+    currency: string;
 };
 
 /**
- * Betalingslenka fra Photon.
+ * Betalingssvaret fra Photon.
  *
- * Appen leste `payment_link` rett fra svaret, men Photon svarer i camelCase.
+ * Appen leste `payment_link` fra svaret, et felt Lepton hadde og Photon ikke
+ * har: `POST /event/<id>/payment` svarer med `checkoutUrl` — lenka til Vipps.
  * Feltet var derfor alltid undefined, og skjermen falt tilbake til
  * arrangementssida på tihlde.org — en nettleser uten innlogging, der brukeren
  * så ut til å ikke være påmeldt i det hele tatt.
  */
-export const toPayment = (payment: PhotonPayment): Payment =>
-    ({
-        order_id: payment.orderId ?? payment.id ?? "",
-        status: payment.status ?? "",
-        payment_link:
-            payment.paymentLink ??
-            payment.paymentUrl ??
-            payment.redirectUrl ??
-            payment.url ??
-            "",
-    }) as unknown as Payment;
+export const toPayment = (payment: PhotonPayment): Payment => ({
+    eventId: payment.eventId,
+    userId: payment.userId,
+    checkoutUrl: payment.checkoutUrl,
+    amount: payment.amount,
+    currency: payment.currency,
+});

--- a/actions/types/payment.ts
+++ b/actions/types/payment.ts
@@ -1,15 +1,9 @@
-import { User } from "./user";
-
 export type Payment = {
-    order_id: string;
-    status: string;
-    user: User;
-    payment_link: string;
-    event: {
-        id: number;
-        title: string;
-        image: string;
-        start_date: string;
-        end_date: string;
-    }
-}
+    eventId: string;
+    userId: string;
+    /** Vipps-checkouten brukeren skal sendes til. */
+    checkoutUrl: string;
+    /** Beløp i øre, slik Photon oppgir det. */
+    amount: number;
+    currency: string;
+};

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -776,7 +776,7 @@ function RegistrationButton({
                 <StatusBanner
                     tone="warning"
                     palette={palette}
-                    message="Plass reservert — venter på betaling"
+                    message="Plassen din er reservert, betal for å sikre den"
                     secondary={paymentDeadlineText(mine, paymentCountdown)}
                 />
             )}

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -10,7 +10,11 @@ import { iAmRegisteredToEvent, registerToEvent, unregisterFromEvent } from "@/ac
 import { Event, Registration } from "@/actions/types";
 import { useEffect, useRef, useState } from "react";
 import useInterval from "@/lib/useInterval";
-import { createPayment } from "@/actions/events/payments";
+import {
+    confirmPayment,
+    createPayment,
+    PaymentConfirmation,
+} from "@/actions/events/payments";
 import { VippsButton } from "@/components/ui/vipps-button";
 import * as WebBrowser from "expo-web-browser";
 import { usePermissions } from "@/actions/users/me";
@@ -979,11 +983,18 @@ function StatusBanner({
 }
 
 
+// Vipps svarer sjelden med en gang. Seks forsøk med to sekunder mellom gir
+// betalingen et drøyt titalls sekunder på å bli bekreftet før vi gir oss og
+// lar arrangementet selv være fasit.
+const PAYMENT_CONFIRM_ATTEMPTS = 6;
+const PAYMENT_CONFIRM_RETRY_MS = 2_000;
+
 function PaymentButton({ eventId }: { eventId: string }) {
     const queryClient = useQueryClient();
 
     // Sant fra vi sender medlemmet til Vipps til appen er i forgrunnen igjen.
     const awaitingVipps = useRef(false);
+    const [isConfirming, setIsConfirming] = useState(false);
 
     // Betalingen fulgte tidligere skjermen: en useQuery som la inn en Vipps-
     // checkout bare av at arrangementet ble åpnet. Vipps-deeplinken varer i
@@ -1027,24 +1038,65 @@ function PaymentButton({ eventId }: { eventId: string }) {
     });
 
     // Med app-bytte er det ingen nettleser som lukker seg, så det er
-    // forgrunnen som forteller at medlemmet er tilbake fra Vipps. Betalingen
-    // bekreftes av Photons webhook, ikke av oss, så her hentes bare status på
-    // nytt.
+    // forgrunnen som forteller at medlemmet er tilbake fra Vipps.
     useEffect(() => {
         const subscription = AppState.addEventListener("change", (state) => {
             if (state !== "active" || !awaitingVipps.current) return;
             awaitingVipps.current = false;
-            queryClient.invalidateQueries({ queryKey: ["event"] });
-            queryClient.refetchQueries({ queryKey: ["event"] });
+            setIsConfirming(true);
         });
 
         return () => subscription.remove();
-    }, [queryClient]);
+    }, []);
+
+    // Vipps slipper medlemmet tilbake i det de har godkjent, som regel før
+    // webhooken har nådd Photon. Da spør vi Photon om å høre med Vipps i
+    // stedet for å la medlemmet stå igjen med «betal for å sikre den» rett
+    // etter å ha betalt.
+    useEffect(() => {
+        if (!isConfirming) return;
+
+        let cancelled = false;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+
+        const ask = async (attempt: number) => {
+            let status: PaymentConfirmation["status"] | null = null;
+            try {
+                status = (await confirmPayment(eventId)).status;
+            } catch {
+                // Nettverket eller API-et svikta. Det er ikke et svar om
+                // betalingen, så vi behandler det som «vet ikke ennå».
+                status = null;
+            }
+            if (cancelled) return;
+
+            // «pending» er det eneste som er verdt å vente på: betalingen er
+            // underveis hos Vipps. Alt annet er et svar.
+            const keepWaiting = status === null || status === "pending";
+            if (keepWaiting && attempt + 1 < PAYMENT_CONFIRM_ATTEMPTS) {
+                timeout = setTimeout(
+                    () => void ask(attempt + 1),
+                    PAYMENT_CONFIRM_RETRY_MS
+                );
+                return;
+            }
+
+            await queryClient.invalidateQueries({ queryKey: ["event"] });
+            if (!cancelled) setIsConfirming(false);
+        };
+
+        void ask(0);
+
+        return () => {
+            cancelled = true;
+            clearTimeout(timeout);
+        };
+    }, [isConfirming, eventId, queryClient]);
 
     return (
         <VippsButton
             className="w-full mb-4"
-            loading={payment.isPending}
+            loading={payment.isPending || isConfirming}
             onPress={() => payment.mutate()}
         />
     );

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -1,14 +1,14 @@
 import { themeColors } from "@/lib/theme/colors";
 import { Text } from "@/components/ui/text";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { View, ActivityIndicator, Pressable } from "react-native";
+import { View, ActivityIndicator, AppState, Linking, Pressable } from "react-native";
 import MarkdownView from "@/components/ui/MarkdownView";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import PageWrapper from "@/components/ui/pagewrapper";
 import { fetchEvent, fetchEventCounts } from "@/actions/events/events";
 import { iAmRegisteredToEvent, registerToEvent, unregisterFromEvent } from "@/actions/events/registrations";
 import { Event, Registration } from "@/actions/types";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useInterval from "@/lib/useInterval";
 import { createPayment } from "@/actions/events/payments";
 import { VippsButton } from "@/components/ui/vipps-button";
@@ -982,36 +982,70 @@ function StatusBanner({
 function PaymentButton({ eventId }: { eventId: string }) {
     const queryClient = useQueryClient();
 
-    const payment = useQuery({
-        queryFn: () => createPayment(eventId),
-        queryKey: ["event", eventId, "payment"],
+    // Sant fra vi sender medlemmet til Vipps til appen er i forgrunnen igjen.
+    const awaitingVipps = useRef(false);
+
+    // Betalingen fulgte tidligere skjermen: en useQuery som la inn en Vipps-
+    // checkout bare av at arrangementet ble åpnet. Vipps-deeplinken varer i
+    // fem minutter, så en lenke laget ved åpning var som regel død når
+    // medlemmet trykte. Nå lages den i trykket.
+    const payment = useMutation({
+        mutationFn: async () => createPayment(eventId),
+        onSuccess: async ({ checkoutUrl }) => {
+            if (!checkoutUrl) {
+                Toast.show({
+                    type: "error",
+                    text1: "Kunne ikke starte betalingen",
+                    text2: "Prøv igjen om litt.",
+                });
+                return;
+            }
+
+            // Photon ber Vipps om NATIVE_REDIRECT, og da er checkoutUrl en
+            // `vipps://`-deeplink som bytter til Vipps-appen. Den kan ikke
+            // åpnes i en nettleser: openBrowserAsync tar bare http og https,
+            // og Vipps krever at lenka åpnes slik den er.
+            try {
+                awaitingVipps.current = true;
+                await Linking.openURL(checkoutUrl);
+            } catch {
+                awaitingVipps.current = false;
+                Toast.show({
+                    type: "error",
+                    text1: "Fikk ikke åpnet Vipps",
+                    text2: "Sjekk at Vipps er installert på telefonen.",
+                });
+            }
+        },
+        onError: (error) => {
+            Toast.show({
+                type: "error",
+                text1: "Kunne ikke starte betalingen",
+                text2: registrationErrorMessage(error),
+            });
+        },
     });
+
+    // Med app-bytte er det ingen nettleser som lukker seg, så det er
+    // forgrunnen som forteller at medlemmet er tilbake fra Vipps. Betalingen
+    // bekreftes av Photons webhook, ikke av oss, så her hentes bare status på
+    // nytt.
+    useEffect(() => {
+        const subscription = AppState.addEventListener("change", (state) => {
+            if (state !== "active" || !awaitingVipps.current) return;
+            awaitingVipps.current = false;
+            queryClient.invalidateQueries({ queryKey: ["event"] });
+            queryClient.refetchQueries({ queryKey: ["event"] });
+        });
+
+        return () => subscription.remove();
+    }, [queryClient]);
 
     return (
         <VippsButton
             className="w-full mb-4"
             loading={payment.isPending}
-            onPress={() => {
-                // Uten en checkout-lenke er det ingenting å åpne. Tidligere
-                // falt vi tilbake til arrangementssida på tihlde.org, men den
-                // nettleseren deler ikke innloggingen med appen — brukeren
-                // havnet på en side der de så ut til å ikke være påmeldt.
-                const checkoutUrl = payment.data?.checkoutUrl;
-                if (!checkoutUrl) {
-                    Toast.show({
-                        type: "error",
-                        text1: "Kunne ikke starte betalingen",
-                        text2: "Prøv igjen om litt.",
-                    });
-                    payment.refetch();
-                    return;
-                }
-
-                WebBrowser.openBrowserAsync(checkoutUrl).then(() => {
-                    queryClient.invalidateQueries({ queryKey: ["event"] });
-                    queryClient.refetchQueries({ queryKey: ["event"] });
-                });
-            }}
+            onPress={() => payment.mutate()}
         />
     );
 }

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -11,6 +11,7 @@ import { Event, Registration } from "@/actions/types";
 import { useRef, useState } from "react";
 import useInterval from "@/lib/useInterval";
 import { createPayment } from "@/actions/events/payments";
+import { VippsButton } from "@/components/ui/vipps-button";
 import * as WebBrowser from "expo-web-browser";
 import { usePermissions } from "@/actions/users/me";
 import Toast from "react-native-toast-message";
@@ -974,7 +975,9 @@ function PaymentButton({ eventId }: { eventId: string }) {
     });
 
     return (
-        <Pressable
+        <VippsButton
+            className="w-full mb-4"
+            loading={payment.isPending}
             onPress={() => {
                 // Uten en checkout-lenke er det ingenting å åpne. Tidligere
                 // falt vi tilbake til arrangementssida på tihlde.org, men den
@@ -996,22 +999,7 @@ function PaymentButton({ eventId }: { eventId: string }) {
                     queryClient.refetchQueries({ queryKey: ["event"] });
                 });
             }}
-            disabled={payment.isPending}
-            className={`h-14 rounded-2xl flex-row items-center justify-center mb-4 active:opacity-80 ${
-                payment.isPending ? 'bg-primary/40 dark:bg-primary/30' : 'bg-primary'
-            }`}
-        >
-            {payment.isPending ? (
-                <ActivityIndicator color="white" />
-            ) : (
-                <>
-                    <CreditCard size={16} color="white" />
-                    <Text className="text-white text-base font-semibold ml-2" style={{ fontFamily: "Inter" }}>
-                        Betal her
-                    </Text>
-                </>
-            )}
-        </Pressable>
+        />
     );
 }
 

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -976,7 +976,21 @@ function PaymentButton({ eventId }: { eventId: string }) {
     return (
         <Pressable
             onPress={() => {
-                const paymentLink = payment.data?.payment_link || "https://tihlde.org/arrangementer/" + eventId;
+                // Uten en betalingslenke er det ingenting å åpne. Tidligere
+                // falt vi tilbake til arrangementssida på tihlde.org, men den
+                // nettleseren deler ikke innloggingen med appen — brukeren
+                // havnet på en side der de så ut til å ikke være påmeldt.
+                const paymentLink = payment.data?.payment_link;
+                if (!paymentLink) {
+                    Toast.show({
+                        type: "error",
+                        text1: "Kunne ikke starte betalingen",
+                        text2: "Prøv igjen om litt.",
+                    });
+                    payment.refetch();
+                    return;
+                }
+
                 WebBrowser.openBrowserAsync(paymentLink).then(() => {
                     queryClient.invalidateQueries({ queryKey: ["event"] });
                     queryClient.refetchQueries({ queryKey: ["event"] });

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -781,6 +781,19 @@ function RegistrationButton({
                 />
             )}
 
+            {state === "cancelled" && (
+                <StatusBanner
+                    tone="error"
+                    palette={palette}
+                    message="Påmeldinga di ble avbrutt"
+                    secondary={
+                        event.is_paid_event
+                            ? "Plassen er gitt videre, som regel fordi betalingsfristen gikk ut. Ta kontakt med arrangøren om du fortsatt vil være med."
+                            : "Plassen er ikke lenger din. Ta kontakt med arrangøren om du fortsatt vil være med."
+                    }
+                />
+            )}
+
             {state === "full" && (
                 <StatusBanner
                     tone="warning"

--- a/app/(app)/(modals)/arrangement/[arrangementId].tsx
+++ b/app/(app)/(modals)/arrangement/[arrangementId].tsx
@@ -976,12 +976,12 @@ function PaymentButton({ eventId }: { eventId: string }) {
     return (
         <Pressable
             onPress={() => {
-                // Uten en betalingslenke er det ingenting å åpne. Tidligere
+                // Uten en checkout-lenke er det ingenting å åpne. Tidligere
                 // falt vi tilbake til arrangementssida på tihlde.org, men den
                 // nettleseren deler ikke innloggingen med appen — brukeren
                 // havnet på en side der de så ut til å ikke være påmeldt.
-                const paymentLink = payment.data?.payment_link;
-                if (!paymentLink) {
+                const checkoutUrl = payment.data?.checkoutUrl;
+                if (!checkoutUrl) {
                     Toast.show({
                         type: "error",
                         text1: "Kunne ikke starte betalingen",
@@ -991,7 +991,7 @@ function PaymentButton({ eventId }: { eventId: string }) {
                     return;
                 }
 
-                WebBrowser.openBrowserAsync(paymentLink).then(() => {
+                WebBrowser.openBrowserAsync(checkoutUrl).then(() => {
                     queryClient.invalidateQueries({ queryKey: ["event"] });
                     queryClient.refetchQueries({ queryKey: ["event"] });
                 });

--- a/components/ui/vipps-button.tsx
+++ b/components/ui/vipps-button.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { ActivityIndicator, Pressable, PressableProps, View } from "react-native";
+import Svg, { Path } from "react-native-svg";
+import { Text } from "@/components/ui/text";
+import { cn } from "@/lib/utils";
+
+// Kvadratisk variant av den offisielle Vipps-knappen
+// (https://developer.vippsmobilepay.com/docs/knowledge-base/buttons/), med
+// samme hjørneradius som resten av designsystemet — identisk med
+// `packages/ui/src/components/ui/vipps-button.tsx` i Photon.
+// Merkefarger: #ff5b24 normal, #db460f nedtrykt, #c9c6d7 deaktivert.
+/**
+ * Vipps-ordmerket. `currentColor` finnes ikke i react-native-svg, så fargen
+ * sendes inn — den er alltid knappens tekstfarge.
+ */
+function VippsWordmark({ color = "white" }: { color?: string }) {
+    return (
+        <Svg width={64} height={18} viewBox="0 0 64 18" fill="none">
+            <Path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M64 5.38c-.72-2.75-2.47-3.84-4.86-3.84-1.93 0-4.36 1.1-4.36 3.72 0 1.7 1.18 3.03 3.09 3.37l1.81.32c1.23.23 1.58.7 1.58 1.32 0 .7-.76 1.1-1.89 1.1-1.48 0-2.4-.52-2.55-2l-2.61.41c.4 2.85 2.96 4.02 5.26 4.02 2.18 0 4.5-1.25 4.5-3.78 0-1.71-1.04-2.96-3-3.33l-1.99-.36c-1.11-.2-1.48-.75-1.48-1.27 0-.67.72-1.1 1.7-1.1 1.26 0 2.15.43 2.19 1.82l2.61-.4ZM5.92 9.7l2.72-7.86h3.19L7.1 13.5H4.73L0 1.84h3.19L5.92 9.7Zm16.69-4.52c0 .93-.74 1.57-1.6 1.57-.87 0-1.61-.64-1.61-1.57S20.14 3.6 21 3.6c.87 0 1.6.65 1.6 1.58Zm.5 4.12c-1.08 1.37-2.2 2.32-4.2 2.32-2.04 0-3.63-1.21-4.86-2.99-.5-.73-1.25-.89-1.81-.5-.51.36-.64 1.13-.16 1.8 1.7 2.56 4.07 4.05 6.83 4.05 2.53 0 4.5-1.2 6.04-3.23.58-.75.56-1.51 0-1.94-.51-.4-1.27-.26-1.85.49Zm7.09-1.66c0 2.38 1.4 3.64 2.96 3.64 1.48 0 3-1.17 3-3.64 0-2.42-1.52-3.6-2.98-3.6-1.58 0-2.98 1.12-2.98 3.6Zm0-4.18v-1.6h-2.9v15.68h2.9v-5.58a4.33 4.33 0 0 0 3.64 1.84c2.65 0 5.25-2.06 5.25-6.3 0-4.06-2.7-5.96-5-5.96-1.83 0-3.09.83-3.89 1.92Zm13.93 4.18c0 2.38 1.4 3.64 2.96 3.64 1.48 0 3-1.17 3-3.64 0-2.42-1.52-3.6-2.98-3.6-1.58 0-2.98 1.12-2.98 3.6Zm0-4.18v-1.6h-2.9v15.68h2.9v-5.58a4.33 4.33 0 0 0 3.64 1.84c2.65 0 5.24-2.06 5.24-6.3 0-4.06-2.7-5.96-5-5.96-1.83 0-3.08.83-3.88 1.92Z"
+                fill={color}
+            />
+        </Svg>
+    );
+}
+
+export type VippsButtonProps = Omit<PressableProps, "children"> & {
+    /** Viser travel-tilstand og skrur av trykk. */
+    loading?: boolean;
+    className?: string;
+};
+
+/**
+ * «Betal med Vipps» i merkevarens egne farger.
+ *
+ * Selvstendig merkeelement som med vilje ikke følger app-temaet — bruk vanlig
+ * `Button` til alt annet. Holdt lik Photons `VippsButton` slik at knappen ser
+ * identisk ut på nett og i appen.
+ */
+const VippsButton = React.forwardRef<
+    React.ElementRef<typeof Pressable>,
+    VippsButtonProps
+>(({ className, loading = false, disabled = false, ...props }, ref) => {
+    const isDisabled = disabled || loading;
+
+    return (
+        <Pressable
+            ref={ref}
+            accessibilityRole="button"
+            accessibilityLabel="Betal med Vipps"
+            accessibilityState={{ disabled: isDisabled, busy: loading }}
+            disabled={isDisabled}
+            className={cn(
+                "h-11 flex-row items-center justify-center gap-1.5 rounded-lg px-6",
+                isDisabled
+                    ? "bg-[#c9c6d7]"
+                    : "bg-[#ff5b24] active:bg-[#db460f]",
+                className
+            )}
+            {...props}
+        >
+            {loading ? (
+                <ActivityIndicator color="white" />
+            ) : (
+                <View className="flex-row items-center gap-1.5">
+                    <Text
+                        className="text-white font-semibold"
+                        style={{ fontSize: 18.5, fontFamily: "Inter" }}
+                    >
+                        Betal med
+                    </Text>
+                    <VippsWordmark />
+                </View>
+            )}
+        </Pressable>
+    );
+});
+VippsButton.displayName = "VippsButton";
+
+export { VippsButton };

--- a/lib/events/registrationState.test.ts
+++ b/lib/events/registrationState.test.ts
@@ -163,14 +163,27 @@ describe("deriveRegistrationState", () => {
         ).toBe("processing");
     });
 
-    it("lar en kansellert påmelding falle tilbake til vinduet", () => {
+    // Tidligere falt «cancelled» ned i vinduet og ga «open» — altså en
+    // påmeldingsknapp. Photon svarer 409 «already registered» så lenge raden
+    // ligger der, så knappen kunne aldri lykkes.
+    it("holder en kansellert påmelding som avbrutt", () => {
         expect(
             deriveRegistrationState(
                 event(),
                 registration({ status: "cancelled" }),
                 NOW,
             ),
-        ).toBe("open");
+        ).toBe("cancelled");
+    });
+
+    it("holder en kansellert påmelding avbrutt også på betalte arrangementer", () => {
+        expect(
+            deriveRegistrationState(
+                event({ is_paid_event: true }),
+                registration({ status: "cancelled", has_paid_order: false }),
+                NOW,
+            ),
+        ).toBe("cancelled");
     });
 });
 

--- a/lib/events/registrationState.ts
+++ b/lib/events/registrationState.ts
@@ -206,7 +206,7 @@ export function registrationErrorMessage(error: unknown): string {
         return "Dette arrangementet krever ingen betaling.";
     }
     if (message.includes("Failed to initiate Vipps payment")) {
-        return "Vipps svarte ikke. Prøv igjen om litt — plassen din står så lenge fristen ikke har gått ut.";
+        return "Vipps svarte ikke. Prøv igjen om litt, plassen din står så lenge fristen ikke har gått ut.";
     }
 
     return message;

--- a/lib/events/registrationState.ts
+++ b/lib/events/registrationState.ts
@@ -15,6 +15,7 @@ export type EventRegistrationState =
     | "processing"
     | "joined"
     | "awaiting-payment"
+    | "cancelled"
     | "on-waitlist"
     | "closed"
     | "full";
@@ -60,6 +61,13 @@ export function deriveRegistrationState(
             return "joined";
         case "waitlisted":
             return "on-waitlist";
+        // Photon setter «cancelled» når plassen er tapt: betalingsfristen gikk
+        // ut, påmeldingen kom inn på et stengt arrangement, eller prikkene
+        // stengte den ute. Uten denne grenen falt tilstanden ned i `default` og
+        // viste «Meld deg på» — en knapp som aldri kunne lykkes, siden Photon
+        // svarer 409 så lenge raden ligger der.
+        case "cancelled":
+            return "cancelled";
         // Påmeldingen står som «pending» til serveren har avgjort om det ble
         // plass eller venteliste. Photon avviser betaling før det er avgjort,
         // så «behandler» gjelder også på betalte arrangementer.
@@ -159,8 +167,10 @@ export function registrationErrorMessage(error: unknown): string {
     if (message.includes("not open for registration")) {
         return "Dette arrangementet er ikke åpent for påmelding.";
     }
+    // Photon svarer dette så lenge det ligger en påmeldingsrad på deg, også
+    // når den er avbrutt — da er «du er påmeldt» direkte feil.
     if (message.includes("already registered")) {
-        return "Du er allerede påmeldt. Dra ned for å oppdatere.";
+        return "Du har allerede en påmelding på dette arrangementet. Dra ned for å oppdatere.";
     }
     if (message.includes("accept the event rules")) {
         return "Du må godkjenne arrangementsreglene før du kan melde deg på. Huk av i varselet over.";


### PR DESCRIPTION
## Problemet

«Betal her» åpnet en innebygd nettleser på arrangementssida på tihlde.org, der brukeren ikke var innlogget og derfor så ut til å ikke være påmeldt.

Årsaken var en kjede av feil, ikke selve nettleseren:

1. `createPayment` leste `payment_link` fra svaret. Det feltet er fra Lepton. Photons `POST /event/:id/payment` svarer med `checkoutUrl` (`createPaymentResponseSchema`), så feltet var alltid `undefined`.
2. Knappen hadde en fallback til `https://tihlde.org/arrangementer/<id>`, som er der den utloggede sida kom fra.
3. Selv med riktig felt ville trykket feilet: Photon ber Vipps om `NATIVE_REDIRECT`, og da er `checkoutUrl` en `vipps://`-deeplink. `WebBrowser.openBrowserAsync` tar bare http og https.

Underveis dukket det opp to ting til, verifisert mot Photon-kildekoden:

4. Tilstandsmaskinen hadde ingen gren for `cancelled`. En påmelding som var kansellert (som regel fordi betalingsfristen gikk ut) falt derfor ned i påmeldingsvinduet og viste «Meld deg på», en knapp Photon svarer 409 på så lenge raden ligger der. Medlemmet fikk «Du er allerede påmeldt» på et arrangement de var kastet ut av.
5. Vipps sender medlemmet tilbake før webhooken har nådd Photon, så statusen sto som ubetalt rett etter betaling. Photon har en `confirm`-rute for dette som Kvark allerede bruker.

## Endringene

- `checkoutUrl` mappes i `actions/photon.ts` som resten av Photon-svarene, og `Payment`-typen speiler det faktiske svaret.
- Fallbacken til tihlde.org er borte.
- Lenka åpnes med `Linking.openURL`, uendret, slik Vipps krever for en deeplink.
- Checkouten lages i trykket, ikke når skjermen åpnes. Deeplinken varer fem minutter, så en lenke laget ved åpning var som regel utløpt. Det fjerner også en `useQuery` på et POST som opprettet en Vipps-checkout bare av at noen så på arrangementet.
- Når medlemmet er tilbake i forgrunnen spør appen Photons `confirm`-rute, seks forsøk med to sekunder mellom, før statusen hentes på nytt.
- `cancelled` er en egen tilstand med et banner som sier hva som skjedde, i stedet for en knapp som ikke kan lykkes.
- Knappen er en RN-port av Photons `VippsButton`: samme merkefarger, mål og ordmerke, så den ser lik ut på nett og i app.
- Tekst: «Plassen din er reservert, betal for å sikre den».

## Verifisert

- `npx tsc --noEmit` rent, `npx expo lint` 0 errors, `npx jest` 55/55 (inkludert to nye tester for `cancelled`; den gamle testen som fastholdt `cancelled` → `open` er snudd).
- Kjørt i iOS-simulator mot produksjon: Vipps-knappen og «Plassen din er reservert»-banneret vist i den ekte `awaiting-payment`-tilstanden, og `cancelled`-banneret vist på et arrangement der påmeldinga var avbrutt.
- At `checkoutUrl` ikke er en http-URL ble bekreftet av at et trykk på et mellomsteg ga «openBrowserAsync … The provided URL is not valid», altså at POST-en svarer med `vipps://`-deeplinken.

## Ikke verifisert

Selve app-byttet til Vipps må testes på en fysisk telefon. Vipps finnes ikke i iOS-simulatoren.

## Kjent, utenfor denne PR-en

Photons påmeldingsrute slår opp påmeldingsraden uten å filtrere på status, så en `cancelled` rad blokkerer en ny påmelding permanent. Det er en Photon-side-fiks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)